### PR TITLE
Add additional parsing for timestamps in metadata

### DIFF
--- a/src/sophys_live_view/widgets/metadata_viewer.py
+++ b/src/sophys_live_view/widgets/metadata_viewer.py
@@ -1,3 +1,5 @@
+from time import ctime
+
 from qtpy.QtCore import Qt
 from qtpy.QtWidgets import (
     QHeaderView,
@@ -35,6 +37,9 @@ class MetadataViewer(IMetadataViewer):
                         sub_key = sub_key[len(key_last_portion) + 1 :]
                     add_metadata_field(key + " - " + sub_key, sub_val, metadata_page)
                 return
+
+            if key == "time":
+                value = f"{value} | {ctime(round(value))}"
 
             key_item = QTableWidgetItem(str(key))
             key_item.setTextAlignment(


### PR DESCRIPTION
<img width="493" height="96" alt="image showing an additional string on the time metadata key indicating the time in a human format" src="https://github.com/user-attachments/assets/8ee1d0b8-beb0-42bd-aee1-7483e095a48a" />
