### PR TITLE
Add varied set of improvements based on user feedback

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -61,6 +61,7 @@ dev = [
     "faker",
     "ruff",
     "py-spy",
+    "memray",
 ]
 all = [
     "sophys_live_view[dev]"

--- a/src/sophys_live_view/utils/bluesky_data_source.py
+++ b/src/sophys_live_view/utils/bluesky_data_source.py
@@ -27,7 +27,7 @@ class DocumentParser(DocumentRouter):
         fields = set()
         fields_name_map = dict()
         for field, field_info in doc["data_keys"].items():
-            if "units" in field_info:
+            if "units" in field_info and field_info["units"] != "":
                 fields_name_map[field] = "{} ({})".format(field, field_info["units"])
 
             fields.add(field)

--- a/src/sophys_live_view/utils/bluesky_data_source.py
+++ b/src/sophys_live_view/utils/bluesky_data_source.py
@@ -17,6 +17,9 @@ class DocumentParser(DocumentRouter):
             if "plan_name" in doc:
                 display_name += " ({})".format(doc.get("plan_name"))
 
+        if "file_name" in doc:
+            display_name += " - {}".format(doc.get("file_name"))
+
         self.on_new_run_started(display_name, doc)
 
     def descriptor(self, doc: EventDescriptor):

--- a/src/sophys_live_view/widgets/main_window.py
+++ b/src/sophys_live_view/widgets/main_window.py
@@ -1,9 +1,10 @@
 from importlib.metadata import version
 from pathlib import Path
+from time import sleep
 
 from qtpy.QtCore import Qt
-from qtpy.QtGui import QIcon
-from qtpy.QtWidgets import QApplication, QMainWindow, QSplitter
+from qtpy.QtGui import QCloseEvent, QIcon
+from qtpy.QtWidgets import QMainWindow, QSplitter
 
 from ..utils.data_source_manager import DataSourceManager
 from .metadata_viewer import MetadataViewer
@@ -78,4 +79,9 @@ class SophysLiveView(QMainWindow):
 
         self.data_source_manager.start()
 
-        QApplication.instance().lastWindowClosed.connect(self.data_source_manager.stop)
+    def closeEvent(self, event: QCloseEvent):  # noqa: N802
+        self.data_source_manager.stop()
+        while self.data_source_manager.isRunning():
+            sleep(0.05)
+
+        event.accept()

--- a/src/sophys_live_view/widgets/metadata_viewer.py
+++ b/src/sophys_live_view/widgets/metadata_viewer.py
@@ -18,6 +18,8 @@ class MetadataViewer(IMetadataViewer):
 
         self._stream_metadata = dict()
 
+        self._tabs = list()
+
         layout = QVBoxLayout()
         self._tab = QTabWidget()
         layout.addWidget(self._tab)
@@ -27,7 +29,12 @@ class MetadataViewer(IMetadataViewer):
         selected_streams_changed.connect(self.change_current_streams)
 
     def change_current_streams(self, new_uids_and_names: list[tuple[str, str]]):
+        # NOTE: This doesn't delete the child tab page widgets.
         self._tab.clear()
+        # This does.
+        for tab in self._tabs:
+            tab.deleteLater()
+        self._tabs.clear()
 
         def add_metadata_field(key, value, metadata_page):
             if isinstance(value, dict):
@@ -84,6 +91,7 @@ class MetadataViewer(IMetadataViewer):
                 )
 
             self._tab.addTab(metadata_page, name)
+            self._tabs.append(metadata_page)
 
     def _add_new_stream(
         self,

--- a/src/sophys_live_view/widgets/plot_display.py
+++ b/src/sophys_live_view/widgets/plot_display.py
@@ -251,6 +251,9 @@ class PlotDisplay(IPlotDisplay):
         if not _is_numeric(x_axis_data) or not _is_numeric(cached_data):
             return
 
+        if len(x_axis_data) != len(cached_data):
+            return
+
         plot_widget = self._plots.widget(tab_index)
         plot_widget.getXAxis().setLabel(
             self._data_aggregator.get_signal_name(uid, x_axis_signal)

--- a/src/sophys_live_view/widgets/signal_selector.py
+++ b/src/sophys_live_view/widgets/signal_selector.py
@@ -391,13 +391,14 @@ class SelectionTable2D(TableScrollArea):
 
         self._selected_x_signal = ""
         self._selected_y_signal = ""
-        self._selected_z_signals = set()
+        self._selected_z_signal = ""
 
         self._old_independent_signals = list()
         self._old_dependent_signals = set()
 
         self._x_buttons_container = QButtonGroup()
         self._y_buttons_container = QButtonGroup()
+        self._z_buttons_container = QButtonGroup()
 
         self._row_data = dict()
 
@@ -449,20 +450,21 @@ class SelectionTable2D(TableScrollArea):
             y_axis_radio_button.clicked.connect(self._change_y_axis_signal)
             self._y_buttons_container.addButton(y_axis_radio_button)
 
-            z_axis_checkbox = QCheckBox()
-            z_axis_checkbox.toggled.connect(self._change_z_axis_signals)
+            z_axis_radio_button = QRadioButton()
+            z_axis_radio_button.clicked.connect(self._change_z_axis_signal)
+            self._z_buttons_container.addButton(z_axis_radio_button)
 
             self._add_row(
-                name, x_axis_radio_button, y_axis_radio_button, z_axis_checkbox
+                name, x_axis_radio_button, y_axis_radio_button, z_axis_radio_button
             )
 
         self._select_default_x_axis_signal(signals)
         self._select_default_y_axis_signal(signals)
-        self._select_default_z_axis_signals(signals)
+        self._select_default_z_axis_signal(signals)
 
         self._change_x_axis_signal(emit=False)
         self._change_y_axis_signal(emit=False)
-        self._change_z_axis_signals()
+        self._change_z_axis_signal()
 
         self.refresh_layout()
 
@@ -544,8 +546,8 @@ class SelectionTable2D(TableScrollArea):
         for row in self._activated_y_axis_rows():
             return self._row_signal(row)
 
-    def _select_default_z_axis_signals(self, signals):
-        """Select the default Z axis signals if they're available, with more priority to old selected signals."""
+    def _select_default_z_axis_signal(self, signals):
+        """Select the default Z axis signal if it's available, with more priority to old selected signals."""
         default_dependent_signals = self._parent.default_dependent_signals
 
         has_dependent = any(s in self._old_dependent_signals for s in signals)
@@ -556,14 +558,11 @@ class SelectionTable2D(TableScrollArea):
             signal = self._row_signal(row)
             if signal in default_dependent_signals:
                 set_checked_no_emit(self._row_widgets[row][3], True)
+                return
 
-    def _get_selected_z_axis_signals(self):
-        selected_signals = set()
-
+    def _get_selected_z_axis_signal(self):
         for row in self._activated_z_axis_rows():
-            selected_signals.add(self._row_signal(row))
-
-        return selected_signals
+            return self._row_signal(row)
 
     def _change_x_axis_signal(self, emit=True):
         self._selected_x_signal = self._get_selected_x_axis_signal()
@@ -576,7 +575,7 @@ class SelectionTable2D(TableScrollArea):
             self.selected_streams_changed.emit(
                 self._selected_x_signal,
                 self._selected_y_signal,
-                self._selected_z_signals,
+                self._selected_z_signal,
             )
 
     def _change_y_axis_signal(self, emit=True):
@@ -590,18 +589,18 @@ class SelectionTable2D(TableScrollArea):
             self.selected_streams_changed.emit(
                 self._selected_x_signal,
                 self._selected_y_signal,
-                self._selected_z_signals,
+                self._selected_z_signal,
             )
 
-    def _change_z_axis_signals(self, emit=True):
-        self._selected_z_signals = self._get_selected_z_axis_signals()
-        self._parent._old_dependent_signals = set(self._selected_z_signals)
+    def _change_z_axis_signal(self, emit=True):
+        self._selected_z_signal = self._get_selected_z_axis_signal()
+        self._parent._old_dependent_signals = set([self._selected_z_signal])
 
         if emit:
             self.selected_streams_changed.emit(
                 self._selected_x_signal,
                 self._selected_y_signal,
-                self._selected_z_signals,
+                self._selected_z_signal,
             )
 
 

--- a/src/sophys_live_view/widgets/signal_selector.py
+++ b/src/sophys_live_view/widgets/signal_selector.py
@@ -364,7 +364,7 @@ class SelectionTable1D(TableScrollArea):
 
         return selected_signals
 
-    def _change_x_axis_signal(self, emit=True):
+    def _change_x_axis_signal(self, state=True, *, emit=True):
         self._selected_x_signal = self._get_selected_x_axis_signal()
         self._old_independent_signals = [self._selected_x_signal]
 
@@ -373,7 +373,7 @@ class SelectionTable1D(TableScrollArea):
                 self._selected_x_signal, self._selected_y_signals
             )
 
-    def _change_y_axis_signals(self, emit=True):
+    def _change_y_axis_signals(self, state=True, *, emit=True):
         self._selected_y_signals = self._get_selected_y_axis_signals()
         self._old_dependent_signals = set(self._selected_y_signals)
 
@@ -564,7 +564,7 @@ class SelectionTable2D(TableScrollArea):
         for row in self._activated_z_axis_rows():
             return self._row_signal(row)
 
-    def _change_x_axis_signal(self, emit=True):
+    def _change_x_axis_signal(self, state=True, *, emit=True):
         self._selected_x_signal = self._get_selected_x_axis_signal()
         self._parent._old_independent_signals = [
             self._selected_x_signal,
@@ -578,7 +578,7 @@ class SelectionTable2D(TableScrollArea):
                 self._selected_z_signal,
             )
 
-    def _change_y_axis_signal(self, emit=True):
+    def _change_y_axis_signal(self, state=True, *, emit=True):
         self._selected_y_signal = self._get_selected_y_axis_signal()
         self._parent._old_independent_signals = [
             self._selected_x_signal,
@@ -592,7 +592,7 @@ class SelectionTable2D(TableScrollArea):
                 self._selected_z_signal,
             )
 
-    def _change_z_axis_signal(self, emit=True):
+    def _change_z_axis_signal(self, state=True, *, emit=True):
         self._selected_z_signal = self._get_selected_z_axis_signal()
         self._parent._old_dependent_signals = set([self._selected_z_signal])
 

--- a/src/sophys_live_view/widgets/signal_selector.py
+++ b/src/sophys_live_view/widgets/signal_selector.py
@@ -220,6 +220,7 @@ class SelectionTable1D(QTableWidget):
                 _f.setItalic(True)
                 item.setFont(_f)
             item.setData(Qt.ItemDataRole.UserRole, signal)
+            item.setFlags(~Qt.ItemFlag.ItemIsEditable)
             self.setItem(index, 0, item)
 
             x_axis_radio_button = QRadioButton()
@@ -338,6 +339,7 @@ class SelectionTable2D(QTableWidget):
                 _f.setItalic(True)
                 item.setFont(_f)
             item.setData(Qt.ItemDataRole.UserRole, signal)
+            item.setFlags(~Qt.ItemFlag.ItemIsEditable)
             self.setItem(index, 0, item)
 
             x_axis_radio_button = QRadioButton()

--- a/tests/widgets/test_signal_selector.py
+++ b/tests/widgets/test_signal_selector.py
@@ -63,7 +63,46 @@ def test_change_signals_1d(data_source_manager, selector, signals_mocker, qtbot)
     with qtbot.waitSignal(
         selector.selected_signals_changed_1d, timeout=1000
     ) as blocker:
-        selector._1d_signal_selection_table.cellWidget(1, 2).click()
+        selector._1d_signal_selection_table._row_widgets[1][2].click()
+
+    assert blocker.args[0] == "timestamp", blocker.args
+    assert "det" in blocker.args[1], blocker.args
+    assert "timestamp" in blocker.args[1], blocker.args
+
+
+def test_maintain_signals_between_runs_1d(
+    data_source_manager, selector, signals_mocker, qtbot
+):
+    uids_and_names = []
+
+    data_source_manager.new_data_stream.connect(
+        lambda uid, subuid, display_name, *_: uids_and_names.append(
+            (subuid, display_name)
+        )
+    )
+    with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
+        data_source_manager.start()
+
+    with qtbot.waitSignal(
+        selector.selected_signals_changed_1d, timeout=1000
+    ) as blocker:
+        signals_mocker.selected_streams_changed.emit(uids_and_names[:1])
+
+    assert "timestamp" not in blocker.args[1], blocker.args
+
+    with qtbot.waitSignal(
+        selector.selected_signals_changed_1d, timeout=1000
+    ) as blocker:
+        selector._1d_signal_selection_table._row_widgets[1][2].click()
+
+    assert blocker.args[0] == "timestamp", blocker.args
+    assert "det" in blocker.args[1], blocker.args
+    assert "timestamp" in blocker.args[1], blocker.args
+
+    with qtbot.waitSignal(
+        selector.selected_signals_changed_1d, timeout=1000
+    ) as blocker:
+        signals_mocker.selected_streams_changed.emit(uids_and_names[1:2])
 
     assert blocker.args[0] == "timestamp", blocker.args
     assert "det" in blocker.args[1], blocker.args


### PR DESCRIPTION
Change set:
- Allow usage of the `file_name` metadata key to further customize the displayed run name, as was done in kbl.
- Fix memory leak in the metadata visualization page, leaking memory for each new run selection.
- Switch from a `QTableWidget` to a `QGridLayout` for the signal selector, removing weird behaviors related to cell selection:

Before:
<img width="441" height="259" alt="image" src="https://github.com/user-attachments/assets/0d832815-9c85-4fe0-8f77-2a876aa4b404" />

After:
<img width="441" height="259" alt="image" src="https://github.com/user-attachments/assets/070f9f70-8e44-4de3-ac5c-dc0e41caa591" />

- Try to maintain signal selection when switching between runs. If the same set of signals is available on the previous and new runs, the old selection will be used instead of the default specified by the run metadata.
- Remove the possibility of selecting multiple signals in 2D plots. This option was getting in the way instead of helping people.