### PR TITLE
Improve setuptools-scm configuration for version labelling

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,8 +32,8 @@ where = ["src"]
 "*" = ["ui/*.ui", "_assets/*"]
 
 [tool.setuptools_scm]
-version_scheme = "post-release"
-local_scheme = "dirty-tag"
+version_scheme = "no-guess-dev"
+local_scheme = "node-and-date"
 version_file = "src/sophys_live_view/__version__.py"
 
 [tool.ruff]


### PR DESCRIPTION
The changes are as follows:


- `post-release` -> `no-guess-dev`: This is the recommended replacement for the previously used option, which is now deprecated.

- `dirty-tag` -> `node-and-date`: This gives us more useful information in case of a dirty package, like the Git commit hash.


Reference: https://setuptools-scm.readthedocs.io/en/latest/extending/#version-number-construction