### PR TITLE
Optimize handling of received data for large datasets

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,20 @@ combine-as-imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = [
+    "--benchmark-disable",
+    "--benchmark-group-by=name",
+    "--benchmark-sort=fullname",
+    "--benchmark-columns=min,max,mean,stddev,rounds",
+    "--benchmark-time-unit=ms",
+]
 
 [project.optional-dependencies]
 dev = [
     "pre-commit",
     "pytest",
     "pytest-qt",
+    "pytest-benchmark",
     "faker",
     "ruff",
     "py-spy",

--- a/src/sophys_live_view/utils/bluesky_data_source.py
+++ b/src/sophys_live_view/utils/bluesky_data_source.py
@@ -6,7 +6,7 @@ import typing
 from event_model import DocumentRouter, Event, EventDescriptor, RunStart, RunStop
 import numpy as np
 
-from .data_source import DataSource
+from .data_source import BatchReceivedDataSource, DataSource
 
 
 class DocumentParser(DocumentRouter):
@@ -86,9 +86,9 @@ class DocumentParser(DocumentRouter):
         pass
 
 
-class BlueskyDataSource(DataSource, DocumentParser):
+class BlueskyDataSource(BatchReceivedDataSource, DocumentParser):
     def __init__(self):
-        DataSource.__init__(self)
+        BatchReceivedDataSource.__init__(self)
         DocumentRouter.__init__(self)
 
         self._run_metadata = dict()
@@ -136,7 +136,7 @@ class BlueskyDataSource(DataSource, DocumentParser):
 
         self._descriptors[descriptor_uid] = start_uid
 
-        self.new_data_stream.emit(
+        self.notify_new_data_stream(
             start_uid,
             self._run_metadata[start_uid]["name"],
             fields,
@@ -153,7 +153,7 @@ class BlueskyDataSource(DataSource, DocumentParser):
         if start_uid is None:
             return
 
-        received_data = {key: np.array([val]) for key, val in values.items()}
+        received_data = {key: [val] for key, val in values.items()}
 
         start_metadata = self._run_metadata[start_uid]["metadata"]
         metadata = defaultdict(lambda: dict())
@@ -173,13 +173,13 @@ class BlueskyDataSource(DataSource, DocumentParser):
             for key in start_metadata["detectors"]:
                 metadata[key]["position"] = position
 
-        received_data["time"] = np.array([timestamp]) - start_metadata.get("time", 0)
-        received_data["seq_num"] = np.array([seq_num])
+        received_data["time"] = [timestamp - start_metadata.get("time", 0)]
+        received_data["seq_num"] = [seq_num]
 
-        self.new_data_received.emit(start_uid, received_data, metadata)
+        self.notify_new_data_received(start_uid, 1, received_data, metadata)
 
     def on_run_ended(self, start_uid):
-        self.data_stream_closed.emit(start_uid)
+        self.notify_data_stream_closed(start_uid)
 
     def __getattribute__(self, attr_name):
         if attr_name == "start":

--- a/src/sophys_live_view/utils/data_source.py
+++ b/src/sophys_live_view/utils/data_source.py
@@ -1,4 +1,12 @@
-from qtpy.QtCore import QThread, Signal
+from collections.abc import MutableSequence
+from dataclasses import dataclass
+from functools import wraps
+from typing import TypeAlias, Union
+
+from qtpy.QtCore import QThread, QTimer, Signal, Slot
+
+DATA_RECEIVED_DATA_TYPE: TypeAlias = dict[str, MutableSequence]
+DATA_RECEIVED_METADATA_TYPE: TypeAlias = dict[str, dict[str, MutableSequence]]
 
 
 class DataSource(QThread):
@@ -10,11 +18,58 @@ class DataSource(QThread):
         str, str, set, dict, set, list, dict
     )  # uid, display_name, fields, fields name map, detectors, motors, metadata
     new_data_received = Signal(
-        str, dict, dict
-    )  # uid, {signal : data}, {signal : metadata}
+        str, int, dict, dict
+    )  # uid, number of events, {signal : data}, {signal : metadata}
     data_stream_closed = Signal(str)  # uid
     go_to_last_automatically = Signal(bool)  # Whether to auto-update the display or not
     loading_status = Signal(str, float)  # status message, completion percentage
+
+    def notify_new_data_stream(
+        self,
+        uid: str,
+        display_name: str,
+        fields: set[str],
+        fields_name_map: dict[str, str],
+        detectors: set[str],
+        motors: list[str],
+        metadata: dict,
+    ) -> None:
+        self.new_data_stream.emit(
+            uid, display_name, fields, fields_name_map, detectors, motors, metadata
+        )
+
+    def notify_new_data_received(
+        self,
+        uid: str,
+        number_of_events: int,
+        data: DATA_RECEIVED_DATA_TYPE,
+        metadata: DATA_RECEIVED_METADATA_TYPE,
+    ) -> None:
+        self.new_data_received.emit(uid, number_of_events, data, metadata)
+
+    def notify_data_stream_closed(self, uid: str) -> None:
+        self.data_stream_closed.emit(uid)
+
+    def notify_go_to_last_automatically(self, auto_update: bool) -> None:
+        self.go_to_last_automatically.emit(auto_update)
+
+    def notify_loading_status(
+        self, status_message: str, completion_percentage: float
+    ) -> None:
+        self.loading_status.emit(status_message, completion_percentage)
+
+    def __init__(self):
+        super().__init__()
+
+        # NOTE: This indirection is required so that we run our code while
+        # the Qt event loop is processing events. If we directly override
+        # the run method instead, this will not occur.
+        self.started.connect(self.process)
+
+    @Slot()
+    def process(self):
+        """Method to process data for this DataSource."""
+        raise NotImplementedError
 
     def start_thread(self):
         """Start processing this DataSource."""
@@ -22,4 +77,113 @@ class DataSource(QThread):
 
     def close_thread(self):
         """Stop processing this DataSource."""
-        QThread.terminate(self)
+        QThread.quit(self)
+
+
+def _ensure_dispatch_timer(func):
+    """
+    Helper for BatchReceivedDataMixin to create ensure a dispatch timer exists when entering a method.
+
+    This needs to be done so that the dispatch timer is created in the appropriate thread context, which
+    is why it cannot be created on __init__ (which is ran in the main thread).
+    """
+
+    @wraps(func)
+    def __inner(self, *args, **kwargs):
+        if not hasattr(self, "_dispatch_timer") and not self._should_passthrough:
+            self._dispatch_timer = QTimer(singleShot=True)
+            self._dispatch_timer.timeout.connect(self._dispatch_data)
+
+        return func(self, *args, **kwargs)
+
+    return __inner
+
+
+class BatchReceivedDataSource(DataSource):
+    """
+    DataSource subclass that batches received data in order to reduce
+    the amount of signals emitted and data copy.
+
+    This is primarily a performance optimization for fast data retrieval,
+    but it does increase the latency in receiving new data.
+    """
+
+    @dataclass
+    class BatchContainerItem:
+        number_of_events: int
+        data: DATA_RECEIVED_DATA_TYPE
+        metadata: DATA_RECEIVED_METADATA_TYPE
+
+        def __iter__(self):
+            return iter((self.number_of_events, self.data, self.metadata))
+
+    BATCH_CONTAINER_TYPE: TypeAlias = dict[str, BatchContainerItem]
+
+    def __init__(self, dispatch_time_ms: int = 50):
+        super().__init__()
+
+        self._should_passthrough = (
+            False  # Testing helper for passing data directly through, without batching.
+        )
+        self._dispatch_time = dispatch_time_ms
+
+        self._batch_container: self.BATCH_CONTAINER_TYPE = dict()
+
+    @_ensure_dispatch_timer
+    def notify_new_data_received(
+        self,
+        uid: str,
+        number_of_events: int,
+        data: DATA_RECEIVED_DATA_TYPE,
+        metadata: DATA_RECEIVED_METADATA_TYPE,
+    ):
+        if self._should_passthrough:
+            return super().notify_new_data_received(
+                uid, number_of_events, data, metadata
+            )
+
+        if uid not in self._batch_container:
+            self._batch_container[uid] = self.BatchContainerItem(
+                number_of_events, data, metadata
+            )
+        else:
+            self._batch_container[uid].number_of_events += number_of_events
+            self._extend_sequences_in_map(self._batch_container[uid].data, data)
+            self._extend_sequences_in_map(self._batch_container[uid].metadata, metadata)
+
+        if not self._dispatch_timer.isActive():
+            self._dispatch_timer.start(self._dispatch_time)
+
+    _RECURSIVE_DICT_TYPE: TypeAlias = dict[
+        str, Union[MutableSequence, "_RECURSIVE_DICT_TYPE"]
+    ]
+
+    def _extend_sequences_in_map(
+        self, original_map: _RECURSIVE_DICT_TYPE, map_to_append: _RECURSIVE_DICT_TYPE
+    ):
+        """Recursively extends mutable sequences inside a dict scructure."""
+        original_keys = set(original_map.keys())
+        to_append_keys = set(map_to_append.keys())
+
+        common_keys = original_keys & to_append_keys
+        for key in common_keys:
+            if isinstance(original_map[key], MutableSequence):
+                assert isinstance(map_to_append[key], MutableSequence)
+                original_map[key].extend(map_to_append[key])
+                continue
+
+            if isinstance(original_map[key], dict):
+                assert isinstance(map_to_append[key], dict)
+                self._extend_sequences_in_map(original_map[key], map_to_append[key])
+                continue
+
+        new_keys = to_append_keys - original_keys
+        for key in new_keys:
+            original_map[key] = map_to_append[key]
+
+    @Slot()
+    def _dispatch_data(self):
+        for uid, (number_of_events, data, metadata) in self._batch_container.items():
+            self.new_data_received.emit(uid, number_of_events, data, metadata)
+
+        self._batch_container.clear()

--- a/src/sophys_live_view/utils/data_source_manager.py
+++ b/src/sophys_live_view/utils/data_source_manager.py
@@ -28,8 +28,8 @@ class DataSourceManager(QThread):
         str, str, str, set, dict, set, list, dict
     )  # uid, subuid, display_name, fields, fields name map, detectors, motors, metadata
     new_data_received = Signal(
-        str, str, dict, dict
-    )  # uid, subuid, {signal : data}, {signal : metadata}
+        str, str, int, dict, dict
+    )  # uid, subuid, number of events, {signal : data}, {signal : metadata}
     data_stream_closed = Signal(str, str)  # uid, subuid
     go_to_last_automatically = Signal(str, bool)  # uid, state
     loading_status = Signal(

--- a/src/sophys_live_view/utils/json_data_source.py
+++ b/src/sophys_live_view/utils/json_data_source.py
@@ -10,7 +10,7 @@ class JSONDataSource(BlueskyDataSource):
 
         self._file_path = pathlib.Path(file_path)
 
-    def run(self):
+    def process(self):
         self.loading_status.emit("Loading JSON file...", 0.0)
 
         file_contents = None

--- a/src/sophys_live_view/utils/kafka_data_source.py
+++ b/src/sophys_live_view/utils/kafka_data_source.py
@@ -62,7 +62,7 @@ class KafkaDataSource(BlueskyDataSource):
                 if self._closed:
                     break
 
-                self._logger.debug("Received new message: %s", str(message))
+                self._logger.debug("Received new message: %s", message)
 
                 done_preloading = message.offset + 1 >= current_offset
                 self.notify_go_to_last_automatically(done_preloading)

--- a/src/sophys_live_view/utils/kafka_data_source.py
+++ b/src/sophys_live_view/utils/kafka_data_source.py
@@ -65,7 +65,7 @@ class KafkaDataSource(BlueskyDataSource):
                 self._logger.debug("Received new message: %s", str(message))
 
                 done_preloading = message.offset + 1 >= current_offset
-                self.go_to_last_automatically.emit(done_preloading)
+                self.notify_go_to_last_automatically(done_preloading)
 
                 document_type, document = message.value
 
@@ -83,7 +83,7 @@ class KafkaDataSource(BlueskyDataSource):
                             * (message.offset - start_offset + 1)
                             / (current_offset - start_offset)
                         )
-                    self.loading_status.emit(
+                    self.notify_loading_status(
                         "Loading runs from Kafka...", completion_percent
                     )
 

--- a/src/sophys_live_view/widgets/plot_display.py
+++ b/src/sophys_live_view/widgets/plot_display.py
@@ -34,6 +34,9 @@ class DataAggregator(QObject):
         new_stream_signal.connect(self._on_new_stream)
         new_data_signal.connect(self._receive_new_data)
 
+        # NOTE: Used for testing.
+        self.total_processed_data_events = 0
+
     def get_data(self, uid: str, signal_name: str, *, force_1d: bool = False):
         data = self._data_cache[uid].get(signal_name, None)
         if force_1d and data is not None:
@@ -97,6 +100,8 @@ class DataAggregator(QObject):
             self.add_custom_signal(subuid, name, expression)
 
         self.new_data_received.emit(subuid)
+
+        self.total_processed_data_events += 1
 
 
 class PlotDisplay(IPlotDisplay):

--- a/src/sophys_live_view/widgets/plot_display.py
+++ b/src/sophys_live_view/widgets/plot_display.py
@@ -83,7 +83,14 @@ class DataAggregator(QObject):
             for detector in metadata.get("detectors", []):
                 self._data_cache[subuid][detector] = np.ones(metadata["shape"]) * np.nan
 
-    def _receive_new_data(self, uid: str, subuid: str, new_data: dict, metadata: dict):
+    def _receive_new_data(
+        self,
+        uid: str,
+        subuid: str,
+        number_of_events: int,
+        new_data: dict,
+        metadata: dict,
+    ):
         for detector_name, detector_values in new_data.items():
             if detector_name in metadata and "position" in metadata[detector_name]:
                 position = metadata[detector_name]["position"]
@@ -101,7 +108,7 @@ class DataAggregator(QObject):
 
         self.new_data_received.emit(subuid)
 
-        self.total_processed_data_events += 1
+        self.total_processed_data_events += number_of_events
 
 
 class PlotDisplay(IPlotDisplay):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,75 +1,122 @@
+from collections import deque
 import pathlib
 import uuid
 
-import numpy as np
 import pytest
 
-from sophys_live_view.utils.data_source import DataSource
+from sophys_live_view.utils.data_source import BatchReceivedDataSource, DataSource
 from sophys_live_view.utils.data_source_manager import DataSourceManager
 
 
-class DummyDataSource(DataSource):
-    def run(self):
-        uid = str(uuid.uuid4())
-        self.new_data_stream.emit(
-            uid,
-            "abc",
-            {"timestamp", "det"},
-            {},
-            set(("det",)),
-            ["timestamp"],
-            {"uid": uid, "stream_name": "abc"},
-        )
-        self.new_data_received.emit(
-            uid,
-            {"timestamp": np.array([1, 2, 3]), "det": np.array([1, 2, 3])},
-            {},
-        )
-        self.new_data_received.emit(
-            uid,
-            {"timestamp": np.array([4, 5, 6]), "det": np.array([5, 6, 7])},
-            {},
+class DummyDataSourceData:
+    def __iter__(self):
+        for type_index in self._order:
+            if type_index == 0:
+                uid = str(uuid.uuid4())
+
+            signal_name, arguments_list = self._data[type_index]
+            yield signal_name, (uid, *arguments_list.popleft())
+
+    def __init__(self):
+        self.new_data_stream = deque(
+            (
+                (
+                    "abc",
+                    {"timestamp", "det"},
+                    {},
+                    set(("det",)),
+                    ["timestamp"],
+                    {"stream_name": "abc"},
+                ),
+                (
+                    "ghi",
+                    {"timestamp", "det", "det2"},
+                    {},
+                    set(("det2",)),
+                    ["timestamp"],
+                    {
+                        "stream_name": "ghi",
+                        "configuration": {"one": "ghi", "two": {"two_three": "ghi"}},
+                    },
+                ),
+            )
         )
 
-        uid = str(uuid.uuid4())
-        self.new_data_stream.emit(
-            uid,
-            "ghi",
-            {"timestamp", "det", "det2"},
-            {},
-            set(("det2",)),
-            ["timestamp"],
-            {
-                "uid": uid,
-                "stream_name": "ghi",
-                "configuration": {"one": "ghi", "two": {"two_three": "ghi"}},
-            },
+        self.new_data_received = deque(
+            (
+                (
+                    3,
+                    {"timestamp": [1, 2, 3], "det": [1, 2, 3]},
+                    {},
+                ),
+                (
+                    3,
+                    {"timestamp": [4, 5, 6], "det": [5, 6, 7]},
+                    {},
+                ),
+                (
+                    3,
+                    {
+                        "timestamp": [1, 2, 3],
+                        "det": [2, 1, 3],
+                        "det2": [9, 8, 7],
+                    },
+                    {},
+                ),
+                (
+                    3,
+                    {
+                        "timestamp": [4, 5, 6],
+                        "det": [5, 9, 6],
+                        "det2": [1, 2, 3],
+                    },
+                    {},
+                ),
+            )
         )
-        self.new_data_received.emit(
-            uid,
-            {
-                "timestamp": np.array([1, 2, 3]),
-                "det": np.array([2, 1, 3]),
-                "det2": np.array([9, 8, 7]),
-            },
-            {},
+
+        self.data_stream_closed = deque(((), ()))
+
+        self._order = (0, 1, 1, 2, 0, 1, 1, 2)
+        self._data = (
+            ("new_data_stream", self.new_data_stream),
+            ("new_data_received", self.new_data_received),
+            ("data_stream_closed", self.data_stream_closed),
         )
-        self.new_data_received.emit(
-            uid,
-            {
-                "timestamp": np.array([4, 5, 6]),
-                "det": np.array([5, 9, 6]),
-                "det2": np.array([1, 2, 3]),
-            },
-            {},
-        )
+
+
+class DummyDataSource(DataSource):
+    def process(self):
+        _data = DummyDataSourceData()
+
+        for signal_name, arguments in _data:
+            getattr(self, signal_name).emit(*arguments)
+
+
+class BatchedDummyDataSource(BatchReceivedDataSource):
+    def process(self):
+        _data = DummyDataSourceData()
+
+        for signal_name, arguments in _data:
+            getattr(self, "notify_" + signal_name)(*arguments)
+
+
+@pytest.fixture
+def dummy_data_source():
+    return DummyDataSource()
+
+
+@pytest.fixture
+def batched_dummy_data_source():
+    return BatchedDummyDataSource()
 
 
 @pytest.fixture
 def data_source_manager():
     manager = DataSourceManager(polling_time=0.05)
-    manager.add_data_source(DummyDataSource())
+
     yield manager
+
     manager.stop()
 
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,66 +1,51 @@
 import time
 from uuid import uuid4
 
-import numpy as np
 import pytest
 from qtpy.QtCore import QObject, Signal
 
-from sophys_live_view.utils.bluesky_data_source import DataSource
-from sophys_live_view.utils.data_source_manager import DataSourceManager
+from sophys_live_view.utils.bluesky_data_source import BatchReceivedDataSource
 from sophys_live_view.widgets import PlotDisplay
 
 
-class BigStreamsDataSource(DataSource):
+class BigStreamsDataSource(BatchReceivedDataSource):
     def __init__(
         self, signals_per_event: int, events_per_stream: int, number_of_streams: int
     ):
         super().__init__()
 
+        self._dispatch_time = 25
+
         self._signals_per_event = signals_per_event
         self._events_per_stream = events_per_stream
         self._number_of_streams = number_of_streams
 
-    def run(self):
+    def process(self):
         def _send_stream():
             uid = str(uuid4())
 
             signals = {f"signal_{n}" for n in range(self._signals_per_event)}
-            self.new_data_stream.emit(
+            self.notify_new_data_stream(
                 uid,
                 "Stream",
                 signals,
                 {},
-                {},
+                set(),
                 [],
                 {},
             )
 
             for i in range(self._events_per_stream):
-                data = {
-                    f"signal_{n}": np.array([i]) for n in range(self._signals_per_event)
-                }
-                self.new_data_received.emit(uid, data, {})
+                data = {f"signal_{n}": [i] for n in range(self._signals_per_event)}
+                self.notify_new_data_received(uid, 1, data, {})
 
-            self.data_stream_closed.emit(uid)
+            self.notify_data_stream_closed(uid)
 
         for _ in range(self._number_of_streams):
             _send_stream()
 
     def total_number_of_events(self):
         return self._events_per_stream * self._number_of_streams
-
-    def close_thread(self):
-        assert not self.isRunning()
-
-
-@pytest.fixture
-def empty_manager():
-    manager = DataSourceManager(polling_time=0.05)
-
-    yield manager
-
-    if manager.isRunning():
-        manager.stop()
 
 
 class MockSignals(QObject):
@@ -76,9 +61,9 @@ def signals_mocker():
 
 
 @pytest.fixture
-def display(empty_manager, signals_mocker, qtbot):
+def display(data_source_manager, signals_mocker, qtbot):
     display = PlotDisplay(
-        empty_manager,
+        data_source_manager,
         signals_mocker.selected_streams_changed,
         signals_mocker.selected_signals_changed_1d,
         signals_mocker.selected_signals_changed_2d,
@@ -101,7 +86,7 @@ def test_big_streams(
     events_per_stream,
     number_of_streams,
     benchmark,
-    empty_manager,
+    data_source_manager,
     display,
     qtbot,
 ):
@@ -114,8 +99,8 @@ def test_big_streams(
         data_source = BigStreamsDataSource(
             signals_per_event, events_per_stream, number_of_streams
         )
-        empty_manager.add_data_source(data_source)
-        empty_manager.start()
+        data_source_manager.add_data_source(data_source)
+        data_source_manager.start()
 
         _start_time = time.time()
         while (
@@ -124,7 +109,7 @@ def test_big_streams(
         ):
             if time.time() - _start_time >= 10.0:
                 pytest.fail(
-                    f"Timed out: Processed {data_aggr.total_processed_data_events} events."
+                    f"Timed out: Processed {data_aggr.total_processed_data_events} events out of {data_source.total_number_of_events()}."
                 )
 
             qtbot.wait(25)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,132 @@
+import time
+from uuid import uuid4
+
+import numpy as np
+import pytest
+from qtpy.QtCore import QObject, Signal
+
+from sophys_live_view.utils.bluesky_data_source import DataSource
+from sophys_live_view.utils.data_source_manager import DataSourceManager
+from sophys_live_view.widgets import PlotDisplay
+
+
+class BigStreamsDataSource(DataSource):
+    def __init__(
+        self, signals_per_event: int, events_per_stream: int, number_of_streams: int
+    ):
+        super().__init__()
+
+        self._signals_per_event = signals_per_event
+        self._events_per_stream = events_per_stream
+        self._number_of_streams = number_of_streams
+
+    def run(self):
+        def _send_stream():
+            uid = str(uuid4())
+
+            signals = {f"signal_{n}" for n in range(self._signals_per_event)}
+            self.new_data_stream.emit(
+                uid,
+                "Stream",
+                signals,
+                {},
+                {},
+                [],
+                {},
+            )
+
+            for i in range(self._events_per_stream):
+                data = {
+                    f"signal_{n}": np.array([i]) for n in range(self._signals_per_event)
+                }
+                self.new_data_received.emit(uid, data, {})
+
+            self.data_stream_closed.emit(uid)
+
+        for _ in range(self._number_of_streams):
+            _send_stream()
+
+    def total_number_of_events(self):
+        return self._events_per_stream * self._number_of_streams
+
+    def close_thread(self):
+        assert not self.isRunning()
+
+
+@pytest.fixture
+def empty_manager():
+    manager = DataSourceManager(polling_time=0.05)
+
+    yield manager
+
+    if manager.isRunning():
+        manager.stop()
+
+
+class MockSignals(QObject):
+    selected_streams_changed = Signal(list)
+    selected_signals_changed_1d = Signal(str, set)
+    selected_signals_changed_2d = Signal(str, str, set)
+    custom_signal_added = Signal(str, str, str)
+
+
+@pytest.fixture
+def signals_mocker():
+    return MockSignals()
+
+
+@pytest.fixture
+def display(empty_manager, signals_mocker, qtbot):
+    display = PlotDisplay(
+        empty_manager,
+        signals_mocker.selected_streams_changed,
+        signals_mocker.selected_signals_changed_1d,
+        signals_mocker.selected_signals_changed_2d,
+        signals_mocker.custom_signal_added,
+    )
+    qtbot.addWidget(display)
+    return display
+
+
+@pytest.mark.benchmark(
+    max_time=10.0,
+    warmup=False,
+)
+@pytest.mark.parametrize(
+    ("signals_per_event", "events_per_stream", "number_of_streams"),
+    ((2, 1000, 10), (10, 1000, 2), (2, 10000, 1), (20, 10000, 1), (200, 1000, 1)),
+)
+def test_big_streams(
+    signals_per_event,
+    events_per_stream,
+    number_of_streams,
+    benchmark,
+    empty_manager,
+    display,
+    qtbot,
+):
+    data_aggr = display._data_aggregator
+
+    @benchmark
+    def __inner():
+        data_aggr.total_processed_data_events = 0
+
+        data_source = BigStreamsDataSource(
+            signals_per_event, events_per_stream, number_of_streams
+        )
+        empty_manager.add_data_source(data_source)
+        empty_manager.start()
+
+        _start_time = time.time()
+        while (
+            data_aggr.total_processed_data_events
+            != data_source.total_number_of_events()
+        ):
+            if time.time() - _start_time >= 10.0:
+                pytest.fail(
+                    f"Timed out: Processed {data_aggr.total_processed_data_events} events."
+                )
+
+            qtbot.wait(25)
+
+    assert __inner is None

--- a/tests/utils/test_data_source.py
+++ b/tests/utils/test_data_source.py
@@ -1,26 +1,25 @@
 import pytest
 
-from sophys_live_view.utils.data_source_manager import DataSourceManager
 from sophys_live_view.utils.json_data_source import JSONDataSource
 
 
-@pytest.fixture
-def empty_manager():
-    manager = DataSourceManager(polling_time=0.05)
-
-    yield manager
-
-    if manager.isRunning():
-        manager.stop()
-
-
-def test_data_source_declare_stream(data_source_manager, qtbot):
+def test_data_source_declare_stream(data_source_manager, dummy_data_source, qtbot):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
 
-def test_data_source_stream_data(data_source_manager, qtbot):
+def test_data_source_stream_data(data_source_manager, dummy_data_source, qtbot):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_received] * 4, timeout=1000):
+        data_source_manager.start()
+
+
+def test_data_source_stream_data_batched(
+    data_source_manager, batched_dummy_data_source, qtbot
+):
+    data_source_manager.add_data_source(batched_dummy_data_source)
+    with qtbot.waitSignals([data_source_manager.new_data_received] * 2, timeout=1000):
         data_source_manager.start()
 
 
@@ -35,22 +34,57 @@ def test_data_source_stream_data(data_source_manager, qtbot):
     ],
 )
 def test_bluesky_load_from_json(
-    empty_manager, file_name, event_count, test_data_path, qtbot
+    data_source_manager, file_name, event_count, test_data_path, qtbot
 ):
     data_source = JSONDataSource(str(test_data_path / file_name))
-    empty_manager.add_data_source(data_source)
+    data_source._should_passthrough = True
+    data_source_manager.add_data_source(data_source)
 
     with qtbot.waitSignals(
-        [empty_manager.new_data_received] * event_count, timeout=2000
+        [data_source_manager.new_data_received] * event_count, timeout=2000
     ):
-        with qtbot.waitSignal(empty_manager.new_data_stream, timeout=1000):
-            empty_manager.start()
+        with qtbot.waitSignal(data_source_manager.new_data_stream, timeout=1000):
+            data_source_manager.start()
 
 
-def test_data_source_after_start(empty_manager, test_data_path, qtbot):
-    empty_manager.start()
+@pytest.mark.parametrize(
+    "file_name,event_count",
+    [
+        ("count_with_rand.json", 50),
+        ("scan_with_rand.json", 11),
+        ("scan_with_det.json", 21),
+        ("grid_with_rand.json", 121),
+        ("grid_with_det.json", 231),
+    ],
+)
+def test_bluesky_load_from_json_batching(
+    data_source_manager, file_name, event_count, test_data_path, qtbot
+):
+    data_source = JSONDataSource(str(test_data_path / file_name))
+    data_source._dispatch_time = 50  # Arbitrary time
+    data_source_manager.add_data_source(data_source)
+
+    with qtbot.waitSignal(
+        data_source_manager.new_data_received, timeout=1000
+    ) as blocker:
+        with qtbot.waitSignal(data_source_manager.new_data_stream, timeout=1000):
+            data_source_manager.start()
+
+    _, _, number_of_events, received_data, _ = blocker.args
+
+    assert all(
+        [len(data_points) == number_of_events for data_points in received_data.values()]
+    )
+    assert number_of_events == event_count, (
+        f"Got: {number_of_events} | Expected: {event_count}"
+    )
+
+
+def test_data_source_after_start(data_source_manager, test_data_path, qtbot):
+    data_source_manager.start()
 
     data_source = JSONDataSource(str(test_data_path / "count_with_rand.json"))
-    with qtbot.waitSignals([empty_manager.new_data_received] * 50, timeout=2000):
-        with qtbot.waitSignal(empty_manager.new_data_stream, timeout=1000):
-            empty_manager.add_data_source(data_source)
+    data_source._should_passthrough = True
+    with qtbot.waitSignals([data_source_manager.new_data_received] * 50, timeout=2000):
+        with qtbot.waitSignal(data_source_manager.new_data_stream, timeout=1000):
+            data_source_manager.add_data_source(data_source)

--- a/tests/widgets/test_metadata_viewer.py
+++ b/tests/widgets/test_metadata_viewer.py
@@ -23,7 +23,7 @@ def viewer(data_source_manager, signals_mocker, qtbot):
     return selector
 
 
-def test_acquire_metadata(viewer, data_source_manager, qtbot):
+def test_acquire_metadata(viewer, data_source_manager, dummy_data_source, qtbot):
     name_to_uid = {}
 
     data_source_manager.new_data_stream.connect(
@@ -44,11 +44,14 @@ def test_acquire_metadata(viewer, data_source_manager, qtbot):
             == "ghi"
         )
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.start()
     qtbot.waitUntil(metadata_complete, timeout=1000)
 
 
-def test_select_stream(viewer, data_source_manager, signals_mocker, qtbot):
+def test_select_stream(
+    viewer, data_source_manager, dummy_data_source, signals_mocker, qtbot
+):
     uids_and_names = []
 
     data_source_manager.new_data_stream.connect(
@@ -62,6 +65,7 @@ def test_select_stream(viewer, data_source_manager, signals_mocker, qtbot):
         assert viewer._tab.tabText(0) == "abc"
         assert viewer._tab.tabText(1) == "ghi"
 
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
@@ -69,17 +73,15 @@ def test_select_stream(viewer, data_source_manager, signals_mocker, qtbot):
     qtbot.waitUntil(tabs_populated, timeout=1000)
 
     abc_page: QTableWidget = viewer._tab.widget(0)
-    assert abc_page.rowCount() == 2
+    assert abc_page.rowCount() == 1
     assert abc_page.item(0, 0).text() == "stream_name"
     assert abc_page.item(0, 1).text() == "abc"
-    assert abc_page.item(1, 0).text() == "uid"
 
     ghi_page: QTableWidget = viewer._tab.widget(1)
-    assert ghi_page.rowCount() == 4
+    assert ghi_page.rowCount() == 3
     assert ghi_page.item(0, 0).text() == "stream_name"
     assert ghi_page.item(0, 1).text() == "ghi"
-    assert ghi_page.item(1, 0).text() == "uid"
-    assert ghi_page.item(2, 0).text() == "configuration - one"
+    assert ghi_page.item(1, 0).text() == "configuration - one"
+    assert ghi_page.item(1, 1).text() == "ghi"
+    assert ghi_page.item(2, 0).text() == "configuration - two - three"
     assert ghi_page.item(2, 1).text() == "ghi"
-    assert ghi_page.item(3, 0).text() == "configuration - two - three"
-    assert ghi_page.item(3, 1).text() == "ghi"

--- a/tests/widgets/test_plot_display.py
+++ b/tests/widgets/test_plot_display.py
@@ -43,13 +43,29 @@ def test_plot_change_tab(display, qtbot):
     assert "1D" in blocker.args[0], blocker.args
 
 
-def test_plot_get_data(data_source_manager, display, qtbot):
+def test_plot_get_data(data_source_manager, dummy_data_source, display, qtbot):
+    data_source_manager.add_data_source(dummy_data_source)
+
     data_aggr = display._data_aggregator
     with qtbot.waitSignals([data_aggr.new_data_received] * 4, timeout=1000):
         data_source_manager.start()
 
 
-def test_plot_draw_1d_curve(data_source_manager, display, signals_mocker, qtbot):
+def test_plot_get_batched_data(
+    data_source_manager, batched_dummy_data_source, display, qtbot
+):
+    data_source_manager.add_data_source(batched_dummy_data_source)
+
+    data_aggr = display._data_aggregator
+    with qtbot.waitSignals([data_aggr.new_data_received] * 2, timeout=1000):
+        data_source_manager.start()
+
+
+def test_plot_draw_1d_curve(
+    data_source_manager, dummy_data_source, display, signals_mocker, qtbot
+):
+    data_source_manager.add_data_source(dummy_data_source)
+
     uids_and_names = []
 
     data_source_manager.new_data_stream.connect(
@@ -74,7 +90,40 @@ def test_plot_draw_1d_curve(data_source_manager, display, signals_mocker, qtbot)
     qtbot.waitUntil(finished_building_plot, timeout=1000)
 
 
-def test_plot_add_custom_signal(data_source_manager, display, signals_mocker, qtbot):
+def test_plot_draw_1d_curve_batched(
+    data_source_manager, batched_dummy_data_source, display, signals_mocker, qtbot
+):
+    data_source_manager.add_data_source(batched_dummy_data_source)
+
+    uids_and_names = []
+
+    data_source_manager.new_data_stream.connect(
+        lambda uid, subuid, display_name, *_: uids_and_names.append(
+            (subuid, display_name)
+        )
+    )
+
+    data_aggr = display._data_aggregator
+    with qtbot.waitSignals([data_aggr.new_data_received] * 2, timeout=1000):
+        data_source_manager.start()
+
+    signals_mocker.selected_streams_changed.emit(uids_and_names)
+    signals_mocker.selected_signals_changed_1d.emit("timestamp", {"det", "det2"})
+
+    def finished_building_plot():
+        assert display._stacked_widget.currentWidget() is display._plots
+        assert len(display._plots.widget(0).getItems()) == 3
+
+    display.show()
+    qtbot.waitExposed(display, timeout=1000)
+    qtbot.waitUntil(finished_building_plot, timeout=1000)
+
+
+def test_plot_add_custom_signal(
+    data_source_manager, dummy_data_source, display, signals_mocker, qtbot
+):
+    data_source_manager.add_data_source(dummy_data_source)
+
     uids_and_names = []
 
     data_source_manager.new_data_stream.connect(
@@ -93,7 +142,10 @@ def test_plot_add_custom_signal(data_source_manager, display, signals_mocker, qt
     det2_data = data_aggr.get_data(uids_and_names[1][0], "det2")
     custom_data = data_aggr.get_data(uids_and_names[1][0], "test")
 
-    assert all(custom_data[i] == det2_data[i] - det_data[i] for i in range(custom_data.shape[0]))
+    assert all(
+        custom_data[i] == det2_data[i] - det_data[i]
+        for i in range(custom_data.shape[0])
+    )
 
 
 # FIXME: Figure out why this test hangs when running with the other plot display tests,

--- a/tests/widgets/test_run_selector.py
+++ b/tests/widgets/test_run_selector.py
@@ -11,9 +11,12 @@ def selector(data_source_manager, qtbot):
     return selector
 
 
-def test_run_selector_basic_load(selector, data_source_manager, qtbot):
+def test_run_selector_basic_load(
+    selector, data_source_manager, dummy_data_source, qtbot
+):
     assert selector._run_list_model.rowCount() == 0
 
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
@@ -24,7 +27,10 @@ def test_run_selector_basic_load(selector, data_source_manager, qtbot):
     assert selector._run_list_model.data(index) == "ghi"
 
 
-def test_run_selector_select_one(selector, data_source_manager, qtbot):
+def test_run_selector_select_one(
+    selector, data_source_manager, dummy_data_source, qtbot
+):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
@@ -35,7 +41,10 @@ def test_run_selector_select_one(selector, data_source_manager, qtbot):
     assert blocker.args[0][0][1] == "ghi", blocker.args[0]
 
 
-def test_run_selector_select_multiple(selector, data_source_manager, qtbot):
+def test_run_selector_select_multiple(
+    selector, data_source_manager, dummy_data_source, qtbot
+):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
@@ -55,7 +64,8 @@ def test_run_selector_select_multiple(selector, data_source_manager, qtbot):
     assert args[0][1][1] == "ghi", args[0]
 
 
-def test_run_selector_bookmark(selector, data_source_manager, qtbot):
+def test_run_selector_bookmark(selector, data_source_manager, dummy_data_source, qtbot):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 

--- a/tests/widgets/test_signal_selector.py
+++ b/tests/widgets/test_signal_selector.py
@@ -22,9 +22,12 @@ def selector(data_source_manager, signals_mocker, qtbot):
     return selector
 
 
-def test_default_signals_1d(data_source_manager, selector, signals_mocker, qtbot):
+def test_default_signals_1d(
+    data_source_manager, dummy_data_source, selector, signals_mocker, qtbot
+):
     uids_and_names = []
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.new_data_stream.connect(
         lambda uid, subuid, display_name, *_: uids_and_names.append(
             (subuid, display_name)
@@ -42,9 +45,12 @@ def test_default_signals_1d(data_source_manager, selector, signals_mocker, qtbot
     assert "det" in blocker.args[1], blocker.args
 
 
-def test_change_signals_1d(data_source_manager, selector, signals_mocker, qtbot):
+def test_change_signals_1d(
+    data_source_manager, dummy_data_source, selector, signals_mocker, qtbot
+):
     uids_and_names = []
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.new_data_stream.connect(
         lambda uid, subuid, display_name, *_: uids_and_names.append(
             (subuid, display_name)
@@ -71,10 +77,11 @@ def test_change_signals_1d(data_source_manager, selector, signals_mocker, qtbot)
 
 
 def test_maintain_signals_between_runs_1d(
-    data_source_manager, selector, signals_mocker, qtbot
+    data_source_manager, dummy_data_source, selector, signals_mocker, qtbot
 ):
     uids_and_names = []
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.new_data_stream.connect(
         lambda uid, subuid, display_name, *_: uids_and_names.append(
             (subuid, display_name)
@@ -109,9 +116,10 @@ def test_maintain_signals_between_runs_1d(
     assert "timestamp" in blocker.args[1], blocker.args
 
 
-def test_add_custom_signal(data_source_manager, selector, qtbot):
+def test_add_custom_signal(data_source_manager, dummy_data_source, selector, qtbot):
     uids_and_names = []
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.new_data_stream.connect(
         lambda uid, subuid, display_name, *_: uids_and_names.append(
             (subuid, display_name)


### PR DESCRIPTION
Here, we do two things:
1. Avoid calling __repr__ on every received message (we hope logging can cast the data on its own).
2. Use Python lists instead of Numpy arrays for internal received data, so that we don't have to reallocate arrays on every received data point.

These changes yield a ~3x improvement on loading on an arbitrary 10-day window in the CNB beamline (~1min30s -> ~30s).