### PR TITLE
Optimize intake of data from DataSources

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,12 +53,20 @@ combine-as-imports = true
 
 [tool.pytest.ini_options]
 testpaths = ["tests"]
+addopts = [
+    "--benchmark-disable",
+    "--benchmark-group-by=name",
+    "--benchmark-sort=fullname",
+    "--benchmark-columns=min,max,mean,stddev,rounds",
+    "--benchmark-time-unit=ms",
+]
 
 [project.optional-dependencies]
 dev = [
     "pre-commit",
     "pytest",
     "pytest-qt",
+    "pytest-benchmark",
     "faker",
     "ruff",
     "py-spy",

--- a/src/sophys_live_view/main.py
+++ b/src/sophys_live_view/main.py
@@ -1,4 +1,6 @@
 import argparse
+import logging
+import logging.config
 import sys
 
 from qtpy.QtWidgets import QApplication
@@ -40,6 +42,12 @@ def entrypoint():
         action="store_true",
         help="Profile this application with memray.",
     )
+    parser.add_argument(
+        "--log-level",
+        type=str,
+        default="INFO",
+        help="Log level for the logging module (default: INFO)",
+    )
 
     args = parser.parse_args()
 
@@ -74,6 +82,34 @@ def entrypoint():
             "You can run something like 'memray flamegraph profile.bin' to generate a report on memory usage."
         )
         return _ret
+
+    logging.config.dictConfig(
+        {
+            "version": 1,
+            "formatters": {
+                "basic": {
+                    "format": "[%(asctime)s %(levelname)s - %(name)s] %(message)s",
+                }
+            },
+            "handlers": {
+                "stream": {
+                    "class": "logging.StreamHandler",
+                    "formatter": "basic",
+                    "level": "DEBUG",
+                },
+            },
+            "loggers": {
+                "": {
+                    "handlers": ["stream"],
+                    "level": logging.INFO,
+                },
+                "sophys.live_view": {
+                    "handlers": ["stream"],
+                    "level": args.log_level,
+                },
+            },
+        }
+    )
 
     return __inner()
 

--- a/src/sophys_live_view/utils/bluesky_data_source.py
+++ b/src/sophys_live_view/utils/bluesky_data_source.py
@@ -1,12 +1,11 @@
 from abc import abstractmethod
 from collections import defaultdict
-from functools import partial
 import typing
 
 from event_model import DocumentRouter, Event, EventDescriptor, RunStart, RunStop
 import numpy as np
 
-from .data_source import BatchReceivedDataSource, DataSource
+from .data_source import BatchReceivedDataSource
 
 
 class DocumentParser(DocumentRouter):
@@ -86,13 +85,18 @@ class DocumentParser(DocumentRouter):
         pass
 
 
-class BlueskyDataSource(BatchReceivedDataSource, DocumentParser):
+class BlueskyDataSource(BatchReceivedDataSource):
     def __init__(self):
-        BatchReceivedDataSource.__init__(self)
-        DocumentRouter.__init__(self)
+        super().__init__()
 
         self._run_metadata = dict()
         self._descriptors = dict()
+
+        self._parser = DocumentParser()
+        self._parser.on_new_run_started = self.on_new_run_started
+        self._parser.on_new_descriptor = self.on_new_descriptor
+        self._parser.on_new_event = self.on_new_event
+        self._parser.on_run_ended = self.on_run_ended
 
     def on_new_run_started(self, display_name: str, metadata: dict):
         uid = metadata["uid"]
@@ -181,14 +185,5 @@ class BlueskyDataSource(BatchReceivedDataSource, DocumentParser):
     def on_run_ended(self, start_uid):
         self.notify_data_stream_closed(start_uid)
 
-    def event(self, event):
-        if isinstance(event, dict):
-            return DocumentParser.event(self, event)
-        return DataSource.event(self, event)
-
-    def __getattribute__(self, attr_name):
-        if attr_name == "start":
-            return partial(DocumentParser.start, self)
-        if attr_name == "stop":
-            return partial(DocumentParser.stop, self)
-        return super().__getattribute__(attr_name)
+    def __call__(self, name, doc):
+        return self._parser(name, doc)

--- a/src/sophys_live_view/utils/bluesky_data_source.py
+++ b/src/sophys_live_view/utils/bluesky_data_source.py
@@ -6,7 +6,7 @@ import typing
 from event_model import DocumentRouter, Event, EventDescriptor, RunStart, RunStop
 import numpy as np
 
-from .data_source import DataSource
+from .data_source import BatchReceivedDataSource, DataSource
 
 
 class DocumentParser(DocumentRouter):
@@ -86,9 +86,9 @@ class DocumentParser(DocumentRouter):
         pass
 
 
-class BlueskyDataSource(DataSource, DocumentParser):
+class BlueskyDataSource(BatchReceivedDataSource, DocumentParser):
     def __init__(self):
-        DataSource.__init__(self)
+        BatchReceivedDataSource.__init__(self)
         DocumentRouter.__init__(self)
 
         self._run_metadata = dict()
@@ -136,7 +136,7 @@ class BlueskyDataSource(DataSource, DocumentParser):
 
         self._descriptors[descriptor_uid] = start_uid
 
-        self.new_data_stream.emit(
+        self.notify_new_data_stream(
             start_uid,
             self._run_metadata[start_uid]["name"],
             fields,
@@ -153,7 +153,7 @@ class BlueskyDataSource(DataSource, DocumentParser):
         if start_uid is None:
             return
 
-        received_data = {key: np.array([val]) for key, val in values.items()}
+        received_data = {key: [val] for key, val in values.items()}
 
         start_metadata = self._run_metadata[start_uid]["metadata"]
         metadata = defaultdict(lambda: dict())
@@ -168,18 +168,18 @@ class BlueskyDataSource(DataSource, DocumentParser):
             if snaking[1] and pos[0] % 2:
                 pos[1] = shape[1] - pos[1] - 1
 
-            position = tuple(map(int, pos))
+            position = list(map(int, pos))
 
             for key in start_metadata["detectors"]:
                 metadata[key]["position"] = position
 
-        received_data["time"] = np.array([timestamp]) - start_metadata.get("time", 0)
-        received_data["seq_num"] = np.array([seq_num])
+        received_data["time"] = [timestamp - start_metadata.get("time", 0)]
+        received_data["seq_num"] = [seq_num]
 
-        self.new_data_received.emit(start_uid, received_data, metadata)
+        self.notify_new_data_received(start_uid, 1, received_data, metadata)
 
     def on_run_ended(self, start_uid):
-        self.data_stream_closed.emit(start_uid)
+        self.notify_data_stream_closed(start_uid)
 
     def __getattribute__(self, attr_name):
         if attr_name == "start":

--- a/src/sophys_live_view/utils/bluesky_data_source.py
+++ b/src/sophys_live_view/utils/bluesky_data_source.py
@@ -168,10 +168,10 @@ class BlueskyDataSource(BatchReceivedDataSource, DocumentParser):
             if snaking[1] and pos[0] % 2:
                 pos[1] = shape[1] - pos[1] - 1
 
-            position = list(map(int, pos))
+            position = tuple(map(int, pos))
 
             for key in start_metadata["detectors"]:
-                metadata[key]["position"] = position
+                metadata[key]["position"] = [position]
 
         received_data["time"] = [timestamp - start_metadata.get("time", 0)]
         received_data["seq_num"] = [seq_num]
@@ -181,15 +181,14 @@ class BlueskyDataSource(BatchReceivedDataSource, DocumentParser):
     def on_run_ended(self, start_uid):
         self.notify_data_stream_closed(start_uid)
 
+    def event(self, event):
+        if isinstance(event, dict):
+            return DocumentParser.event(self, event)
+        return DataSource.event(self, event)
+
     def __getattribute__(self, attr_name):
         if attr_name == "start":
             return partial(DocumentParser.start, self)
-        if attr_name == "event":
-            return partial(DocumentParser.event, self)
         if attr_name == "stop":
             return partial(DocumentParser.stop, self)
         return super().__getattribute__(attr_name)
-
-    def start_thread(self):
-        """Needed because DocumentParser overrides the 'start' method."""
-        DataSource.start(self)

--- a/src/sophys_live_view/utils/data_source.py
+++ b/src/sophys_live_view/utils/data_source.py
@@ -3,7 +3,9 @@ from dataclasses import dataclass
 from functools import wraps
 from typing import TypeAlias, Union
 
-from qtpy.QtCore import QThread, QTimer, Signal, Slot
+from qtpy.QtCore import Qt, QThread, QTimer, Signal, Slot
+
+from .thread_utils import _ProxyThreadObject, is_main_thread
 
 DATA_RECEIVED_DATA_TYPE: TypeAlias = dict[str, MutableSequence]
 DATA_RECEIVED_METADATA_TYPE: TypeAlias = dict[str, dict[str, MutableSequence]]
@@ -61,10 +63,7 @@ class DataSource(QThread):
     def __init__(self):
         super().__init__()
 
-        # NOTE: This indirection is required so that we run our code while
-        # the Qt event loop is processing events. If we directly override
-        # the run method instead, this will not occur.
-        self.started.connect(self.process)
+        self.__inner_obj = _ProxyThreadObject(self, self.process)
 
     @Slot()
     def process(self):
@@ -90,9 +89,12 @@ def _ensure_dispatch_timer(func):
 
     @wraps(func)
     def __inner(self, *args, **kwargs):
+        __tracebackhide__ = True
         if not hasattr(self, "_dispatch_timer") and not self._should_passthrough:
             self._dispatch_timer = QTimer(singleShot=True)
-            self._dispatch_timer.timeout.connect(self._dispatch_data)
+            self._dispatch_timer.timeout.connect(
+                self._dispatch_data, type=Qt.ConnectionType.DirectConnection
+            )
 
         return func(self, *args, **kwargs)
 
@@ -183,6 +185,10 @@ class BatchReceivedDataSource(DataSource):
 
     @Slot()
     def _dispatch_data(self):
+        assert not is_main_thread(QThread.currentThread()), (
+            "Running processing in main thread!"
+        )
+
         for uid, (number_of_events, data, metadata) in self._batch_container.items():
             self.new_data_received.emit(uid, number_of_events, data, metadata)
 

--- a/src/sophys_live_view/utils/data_source.py
+++ b/src/sophys_live_view/utils/data_source.py
@@ -1,4 +1,12 @@
-from qtpy.QtCore import QThread, Signal
+from collections.abc import MutableSequence
+from dataclasses import dataclass
+from functools import wraps
+from typing import TypeAlias, Union
+
+from qtpy.QtCore import QThread, QTimer, Signal, Slot
+
+DATA_RECEIVED_DATA_TYPE: TypeAlias = dict[str, MutableSequence]
+DATA_RECEIVED_METADATA_TYPE: TypeAlias = dict[str, dict[str, MutableSequence]]
 
 
 class DataSource(QThread):
@@ -10,11 +18,58 @@ class DataSource(QThread):
         str, str, set, dict, set, list, dict
     )  # uid, display_name, fields, fields name map, detectors, motors, metadata
     new_data_received = Signal(
-        str, dict, dict
-    )  # uid, {signal : data}, {signal : metadata}
+        str, int, dict, dict
+    )  # uid, number of events, {signal : data}, {signal : metadata}
     data_stream_closed = Signal(str)  # uid
     go_to_last_automatically = Signal(bool)  # Whether to auto-update the display or not
     loading_status = Signal(str, float)  # status message, completion percentage
+
+    def notify_new_data_stream(
+        self,
+        uid: str,
+        display_name: str,
+        fields: set[str],
+        fields_name_map: dict[str, str],
+        detectors: set[str],
+        motors: list[str],
+        metadata: dict,
+    ) -> None:
+        self.new_data_stream.emit(
+            uid, display_name, fields, fields_name_map, detectors, motors, metadata
+        )
+
+    def notify_new_data_received(
+        self,
+        uid: str,
+        number_of_events: int,
+        data: DATA_RECEIVED_DATA_TYPE,
+        metadata: DATA_RECEIVED_METADATA_TYPE,
+    ) -> None:
+        self.new_data_received.emit(uid, number_of_events, data, metadata)
+
+    def notify_data_stream_closed(self, uid: str) -> None:
+        self.data_stream_closed.emit(uid)
+
+    def notify_go_to_last_automatically(self, auto_update: bool) -> None:
+        self.go_to_last_automatically.emit(auto_update)
+
+    def notify_loading_status(
+        self, status_message: str, completion_percentage: float
+    ) -> None:
+        self.loading_status.emit(status_message, completion_percentage)
+
+    def __init__(self):
+        super().__init__()
+
+        # NOTE: This indirection is required so that we run our code while
+        # the Qt event loop is processing events. If we directly override
+        # the run method instead, this will not occur.
+        self.started.connect(self.process)
+
+    @Slot()
+    def process(self):
+        """Method to process data for this DataSource."""
+        raise NotImplementedError
 
     def start_thread(self):
         """Start processing this DataSource."""
@@ -22,4 +77,113 @@ class DataSource(QThread):
 
     def close_thread(self):
         """Stop processing this DataSource."""
-        QThread.terminate(self)
+        QThread.quit(self)
+
+
+def _ensure_dispatch_timer(func):
+    """
+    Helper for BatchReceivedDataMixin to create ensure a dispatch timer exists when entering a method.
+
+    This needs to be done so that the dispatch timer is created in the appropriate thread context, which
+    is why it cannot be created on __init__ (which is ran in the main thread).
+    """
+
+    @wraps(func)
+    def __inner(self, *args, **kwargs):
+        if not hasattr(self, "_dispatch_timer") and not self._should_passthrough:
+            self._dispatch_timer = QTimer(singleShot=True)
+            self._dispatch_timer.timeout.connect(self._dispatch_data)
+
+        return func(self, *args, **kwargs)
+
+    return __inner
+
+
+class BatchReceivedDataSource(DataSource):
+    """
+    DataSource subclass that batches received data in order to reduce
+    the amount of signals emitted and data copy.
+
+    This is primarily a performance optimization for fast data retrieval,
+    but it does increase the latency in receiving new data.
+    """
+
+    @dataclass
+    class BatchContainerItem:
+        number_of_events: int
+        data: DATA_RECEIVED_DATA_TYPE
+        metadata: DATA_RECEIVED_METADATA_TYPE
+
+        def __iter__(self):
+            return iter((self.number_of_events, self.data, self.metadata))
+
+    BATCH_CONTAINER_TYPE: TypeAlias = dict[str, BatchContainerItem]
+
+    def __init__(self, dispatch_time_ms: int = 50):
+        super().__init__()
+
+        self._should_passthrough = (
+            False  # Testing helper for passing data directly through, without batching.
+        )
+        self._dispatch_time = dispatch_time_ms
+
+        self._batch_container: self.BATCH_CONTAINER_TYPE = dict()
+
+    @_ensure_dispatch_timer
+    def notify_new_data_received(
+        self,
+        uid: str,
+        number_of_events: int,
+        data: DATA_RECEIVED_DATA_TYPE,
+        metadata: DATA_RECEIVED_METADATA_TYPE,
+    ):
+        if self._should_passthrough:
+            return super().notify_new_data_received(
+                uid, number_of_events, data, metadata
+            )
+
+        if uid not in self._batch_container:
+            self._batch_container[uid] = self.BatchContainerItem(
+                number_of_events, data, metadata
+            )
+        else:
+            self._batch_container[uid].number_of_events += number_of_events
+            self._extend_sequences_in_map(self._batch_container[uid].data, data)
+            self._extend_sequences_in_map(self._batch_container[uid].metadata, metadata)
+
+        if not self._dispatch_timer.isActive():
+            self._dispatch_timer.start(self._dispatch_time)
+
+    _RECURSIVE_DICT_TYPE: TypeAlias = dict[
+        str, Union[MutableSequence, "_RECURSIVE_DICT_TYPE"]
+    ]
+
+    def _extend_sequences_in_map(
+        self, original_map: _RECURSIVE_DICT_TYPE, map_to_append: _RECURSIVE_DICT_TYPE
+    ):
+        """Recursively extends mutable sequences inside a dict scructure."""
+        original_keys = set(original_map.keys())
+        to_append_keys = set(map_to_append.keys())
+
+        common_keys = original_keys & to_append_keys
+        for key in common_keys:
+            if isinstance(original_map[key], MutableSequence):
+                assert isinstance(map_to_append[key], MutableSequence)
+                original_map[key].extend(map_to_append[key])
+                continue
+
+            if isinstance(original_map[key], dict):
+                assert isinstance(map_to_append[key], dict)
+                self._extend_sequences_in_map(original_map[key], map_to_append[key])
+                continue
+
+        new_keys = to_append_keys - original_keys
+        for key in new_keys:
+            original_map[key] = map_to_append[key]
+
+    @Slot()
+    def _dispatch_data(self):
+        for uid, (number_of_events, data, metadata) in self._batch_container.items():
+            self.new_data_received.emit(uid, number_of_events, data, metadata)
+
+        self._batch_container.clear()

--- a/src/sophys_live_view/utils/data_source.py
+++ b/src/sophys_live_view/utils/data_source.py
@@ -1,9 +1,8 @@
 from collections.abc import MutableSequence
 from dataclasses import dataclass
-from functools import wraps
 from typing import TypeAlias, Union
 
-from qtpy.QtCore import Qt, QThread, QTimer, Signal, Slot
+from qtpy.QtCore import QObject, Qt, QThread, QTimer, Signal, Slot
 
 from .thread_utils import _ProxyThreadObject, is_main_thread
 
@@ -11,7 +10,7 @@ DATA_RECEIVED_DATA_TYPE: TypeAlias = dict[str, MutableSequence]
 DATA_RECEIVED_METADATA_TYPE: TypeAlias = dict[str, dict[str, MutableSequence]]
 
 
-class DataSource(QThread):
+class DataSource(QObject):
     """
     The base for any DataSource, containing the required signals and some common functionality.
     """
@@ -63,7 +62,20 @@ class DataSource(QThread):
     def __init__(self):
         super().__init__()
 
-        self.__inner_obj = _ProxyThreadObject(self, self.process)
+        self._thread = QThread()
+        self.moveToThread(self._thread)
+
+        self.__inner_obj = _ProxyThreadObject(self._thread, self._start_processing)
+
+    @Slot()
+    def _start_processing(self):
+        self._polling_timer = QTimer()
+        self._polling_timer.setSingleShot(False)
+        self._polling_timer.setInterval(25)
+        self._polling_timer.timeout.connect(self.process)
+        self._polling_timer.start()
+
+        self._thread.finished.connect(self._polling_timer.stop)
 
     @Slot()
     def process(self):
@@ -72,33 +84,15 @@ class DataSource(QThread):
 
     def start_thread(self):
         """Start processing this DataSource."""
-        QThread.start(self)
+        self._thread.start()
 
     def close_thread(self):
         """Stop processing this DataSource."""
-        QThread.quit(self)
+        self._thread.quit()
 
-
-def _ensure_dispatch_timer(func):
-    """
-    Helper for BatchReceivedDataMixin to create ensure a dispatch timer exists when entering a method.
-
-    This needs to be done so that the dispatch timer is created in the appropriate thread context, which
-    is why it cannot be created on __init__ (which is ran in the main thread).
-    """
-
-    @wraps(func)
-    def __inner(self, *args, **kwargs):
-        __tracebackhide__ = True
-        if not hasattr(self, "_dispatch_timer") and not self._should_passthrough:
-            self._dispatch_timer = QTimer(singleShot=True)
-            self._dispatch_timer.timeout.connect(
-                self._dispatch_data, type=Qt.ConnectionType.DirectConnection
-            )
-
-        return func(self, *args, **kwargs)
-
-    return __inner
+    def wait(self):
+        """Wait until this DataSource stops processing."""
+        self._thread.wait()
 
 
 class BatchReceivedDataSource(DataSource):
@@ -131,7 +125,16 @@ class BatchReceivedDataSource(DataSource):
 
         self._batch_container: self.BATCH_CONTAINER_TYPE = dict()
 
-    @_ensure_dispatch_timer
+    def _start_processing(self):
+        super()._start_processing()
+
+        self._dispatch_timer = QTimer(singleShot=True)
+        self._dispatch_timer.timeout.connect(
+            self._dispatch_data, type=Qt.ConnectionType.DirectConnection
+        )
+
+        self._thread.finished.connect(self._dispatch_timer.stop)
+
     def notify_new_data_received(
         self,
         uid: str,

--- a/src/sophys_live_view/utils/data_source.py
+++ b/src/sophys_live_view/utils/data_source.py
@@ -2,7 +2,7 @@ from collections.abc import MutableSequence
 from dataclasses import dataclass
 from typing import TypeAlias, Union
 
-from qtpy.QtCore import QObject, Qt, QThread, QTimer, Signal, Slot
+from qtpy.QtCore import QObject, Qt, QThread, Signal, Slot
 
 from .thread_utils import _ProxyThreadObject, is_main_thread
 
@@ -24,6 +24,9 @@ class DataSource(QObject):
     data_stream_closed = Signal(str)  # uid
     go_to_last_automatically = Signal(bool)  # Whether to auto-update the display or not
     loading_status = Signal(str, float)  # status message, completion percentage
+
+    reprocess = Signal()
+    """Signal for triggering reprocessing of this DataSource"""
 
     def notify_new_data_stream(
         self,
@@ -69,13 +72,8 @@ class DataSource(QObject):
 
     @Slot()
     def _start_processing(self):
-        self._polling_timer = QTimer()
-        self._polling_timer.setSingleShot(False)
-        self._polling_timer.setInterval(25)
-        self._polling_timer.timeout.connect(self.process)
-        self._polling_timer.start()
-
-        self._thread.finished.connect(self._polling_timer.stop)
+        self.reprocess.connect(self.process, type=Qt.ConnectionType.QueuedConnection)
+        self.reprocess.emit()
 
     @Slot()
     def process(self):
@@ -104,6 +102,9 @@ class BatchReceivedDataSource(DataSource):
     but it does increase the latency in receiving new data.
     """
 
+    dispatch_data = Signal()
+    """Signal used to signal to the DataSource to dispatch all its accumulated data."""
+
     @dataclass
     class BatchContainerItem:
         number_of_events: int
@@ -115,25 +116,18 @@ class BatchReceivedDataSource(DataSource):
 
     BATCH_CONTAINER_TYPE: TypeAlias = dict[str, BatchContainerItem]
 
-    def __init__(self, dispatch_time_ms: int = 50):
+    def __init__(self):
         super().__init__()
 
         self._should_passthrough = (
             False  # Testing helper for passing data directly through, without batching.
         )
-        self._dispatch_time = dispatch_time_ms
 
         self._batch_container: self.BATCH_CONTAINER_TYPE = dict()
 
-    def _start_processing(self):
-        super()._start_processing()
-
-        self._dispatch_timer = QTimer(singleShot=True)
-        self._dispatch_timer.timeout.connect(
-            self._dispatch_data, type=Qt.ConnectionType.DirectConnection
+        self.dispatch_data.connect(
+            self._dispatch_data, type=Qt.ConnectionType.QueuedConnection
         )
-
-        self._thread.finished.connect(self._dispatch_timer.stop)
 
     def notify_new_data_received(
         self,
@@ -155,9 +149,6 @@ class BatchReceivedDataSource(DataSource):
             self._batch_container[uid].number_of_events += number_of_events
             self._extend_sequences_in_map(self._batch_container[uid].data, data)
             self._extend_sequences_in_map(self._batch_container[uid].metadata, metadata)
-
-        if not self._dispatch_timer.isActive():
-            self._dispatch_timer.start(self._dispatch_time)
 
     _RECURSIVE_DICT_TYPE: TypeAlias = dict[
         str, Union[MutableSequence, "_RECURSIVE_DICT_TYPE"]

--- a/src/sophys_live_view/utils/data_source.py
+++ b/src/sophys_live_view/utils/data_source.py
@@ -169,15 +169,12 @@ class BatchReceivedDataSource(DataSource):
 
         common_keys = original_keys & to_append_keys
         for key in common_keys:
-            if isinstance(original_map[key], MutableSequence):
-                assert isinstance(map_to_append[key], MutableSequence)
-                original_map[key].extend(map_to_append[key])
-                continue
-
             if isinstance(original_map[key], dict):
                 assert isinstance(map_to_append[key], dict)
                 self._extend_sequences_in_map(original_map[key], map_to_append[key])
                 continue
+
+            original_map[key].extend(map_to_append[key])
 
         new_keys = to_append_keys - original_keys
         for key in new_keys:

--- a/src/sophys_live_view/utils/data_source_manager.py
+++ b/src/sophys_live_view/utils/data_source_manager.py
@@ -1,5 +1,4 @@
-from threading import Lock
-import time
+from threading import Event
 import uuid
 
 from qtpy.QtCore import QThread, Signal
@@ -13,11 +12,6 @@ class DataSourceManager(QThread):
 
     This entity is responsible for managing the lifecycle of DataSources once
     they're added to it, and proxying signal emittions with some data injection taking place.
-
-    Parameters
-    ----------
-    polling_time: float, optional
-        The polling time, in seconds, for new data sources. Defaults to 200ms.
     """
 
     # Here, we have a UID referent to the DataSource from which the data originates from,
@@ -36,61 +30,56 @@ class DataSourceManager(QThread):
         str, str, float
     )  # uid, status message, completion percentage
 
-    def __init__(self, polling_time: float = 0.2):
+    def __init__(self):
         super().__init__()
 
-        self._polling_time = polling_time
-
         self._data_sources = dict()
-        self._data_sources_lock = Lock()
+        self._data_sources_have_updates = Event()
 
         self._unvisited_data_sources = set()
         self._visited_data_sources = set()
 
     def add_data_source(self, data_source: DataSource):
-        with self._data_sources_lock:
-            data_source_uid = str(uuid.uuid4())
-            self._data_sources[data_source_uid] = data_source
+        data_source_uid = str(uuid.uuid4())
+        self._data_sources[data_source_uid] = data_source
 
-            def new_data_stream_wrapper(uid, *args):
-                self.new_data_stream.emit(data_source_uid, uid, *args)
+        def new_data_stream_wrapper(uid, *args):
+            self.new_data_stream.emit(data_source_uid, uid, *args)
 
-            data_source.new_data_stream.connect(new_data_stream_wrapper)
+        data_source.new_data_stream.connect(new_data_stream_wrapper)
 
-            def new_data_received_wrapper(uid, *args):
-                self.new_data_received.emit(data_source_uid, uid, *args)
+        def new_data_received_wrapper(uid, *args):
+            self.new_data_received.emit(data_source_uid, uid, *args)
 
-            data_source.new_data_received.connect(new_data_received_wrapper)
+        data_source.new_data_received.connect(new_data_received_wrapper)
 
-            def data_stream_closed_wrapper(uid, *args):
-                self.data_stream_closed.emit(data_source_uid, uid, *args)
+        def data_stream_closed_wrapper(uid, *args):
+            self.data_stream_closed.emit(data_source_uid, uid, *args)
 
-            data_source.data_stream_closed.connect(data_stream_closed_wrapper)
+        data_source.data_stream_closed.connect(data_stream_closed_wrapper)
 
-            def go_to_last_automatically_wrapper(*args):
-                self.go_to_last_automatically.emit(data_source_uid, *args)
+        def go_to_last_automatically_wrapper(*args):
+            self.go_to_last_automatically.emit(data_source_uid, *args)
 
-            data_source.go_to_last_automatically.connect(
-                go_to_last_automatically_wrapper
-            )
+        data_source.go_to_last_automatically.connect(
+            go_to_last_automatically_wrapper
+        )
 
-            def loading_status_wrapper(*args):
-                self.loading_status.emit(data_source_uid, *args)
+        def loading_status_wrapper(*args):
+            self.loading_status.emit(data_source_uid, *args)
 
-            data_source.loading_status.connect(loading_status_wrapper)
+        data_source.loading_status.connect(loading_status_wrapper)
 
-            self._unvisited_data_sources.add(data_source_uid)
+        self._unvisited_data_sources.add(data_source_uid)
+
+        self._data_sources_have_updates.set()
 
     def run(self):
-        # Here we should pull from data sources which do not provide us with asynchronous data.
+        while self._data_sources_have_updates.wait():
+            if self.isInterruptionRequested():
+                break
 
-        while not self.isInterruptionRequested():
-            with self._data_sources_lock:
-                if len(self._unvisited_data_sources) == 0:
-                    time.sleep(self._polling_time)
-
-                    continue
-
+            while len(self._unvisited_data_sources) > 0:
                 data_source_uid = self._unvisited_data_sources.pop()
                 data_source = self._data_sources[data_source_uid]
 
@@ -98,11 +87,13 @@ class DataSourceManager(QThread):
 
                 self._visited_data_sources.add(data_source_uid)
 
+            self._data_sources_have_updates.clear()
+
     def stop(self):
         self.requestInterruption()
+        self._data_sources_have_updates.set()
 
-        with self._data_sources_lock:
-            for data_source in self._data_sources.values():
-                data_source.close_thread()
-            for data_source in self._data_sources.values():
-                data_source.wait()
+        for data_source in self._data_sources.values():
+            data_source.close_thread()
+        for data_source in self._data_sources.values():
+            data_source.wait()

--- a/src/sophys_live_view/utils/data_source_manager.py
+++ b/src/sophys_live_view/utils/data_source_manager.py
@@ -22,8 +22,8 @@ class DataSourceManager(QThread):
         str, str, str, set, dict, set, list, dict
     )  # uid, subuid, display_name, fields, fields name map, detectors, motors, metadata
     new_data_received = Signal(
-        str, str, dict, dict
-    )  # uid, subuid, {signal : data}, {signal : metadata}
+        str, str, int, dict, dict
+    )  # uid, subuid, number of events, {signal : data}, {signal : metadata}
     data_stream_closed = Signal(str, str)  # uid, subuid
     go_to_last_automatically = Signal(str, bool)  # uid, state
     loading_status = Signal(

--- a/src/sophys_live_view/utils/json_data_source.py
+++ b/src/sophys_live_view/utils/json_data_source.py
@@ -21,3 +21,5 @@ class JSONDataSource(BlueskyDataSource):
             self(document_type, document)
 
         self.loading_status.emit("Loading JSON file...", 100.0)
+
+        self.dispatch_data.emit()

--- a/src/sophys_live_view/utils/json_data_source.py
+++ b/src/sophys_live_view/utils/json_data_source.py
@@ -10,7 +10,7 @@ class JSONDataSource(BlueskyDataSource):
 
         self._file_path = pathlib.Path(file_path)
 
-    def run(self):
+    def process(self):
         self.loading_status.emit("Loading JSON file...", 0.0)
 
         file_contents = None

--- a/src/sophys_live_view/utils/kafka_data_source.py
+++ b/src/sophys_live_view/utils/kafka_data_source.py
@@ -95,6 +95,18 @@ class KafkaDataSource(BlueskyDataSource):
 
                 self(document_type, document)
 
+        incoming_bytes = (
+            self._consumer.metrics()
+            .get("consumer-metrics", {})
+            .get("incoming-byte-rate", 0)
+        )
+        self._logger.debug(
+            "Total received data in last 5s (kB): %.2f", incoming_bytes / 1024
+        )
+
+        self.dispatch_data.emit()
+        self.reprocess.emit()
+
     def close_thread(self):
         self._closed = True
 

--- a/src/sophys_live_view/utils/kafka_data_source.py
+++ b/src/sophys_live_view/utils/kafka_data_source.py
@@ -25,46 +25,52 @@ class KafkaDataSource(BlueskyDataSource):
 
         self._closed = False
 
-    def run(self):
-        consumer = KafkaConsumer(
+    def _start_processing(self):
+        self._consumer = KafkaConsumer(
             self._topic_name,
             bootstrap_servers=self._bootstrap_servers,
             value_deserializer=msgpack.unpackb,
             consumer_timeout_ms=250,
         )
 
-        all_partitions = [
+        self._all_partitions = [
             TopicPartition(self._topic_name, p)
-            for p in consumer.partitions_for_topic(self._topic_name)
+            for p in self._consumer.partitions_for_topic(self._topic_name)
         ]
 
-        start_offset = 0
+        self._start_offset = 0
         if self._hour_offset:
             now = datetime.now(timezone.utc)
             hour_offset = int(
                 (now - timedelta(hours=self._hour_offset)).timestamp() * 1000
             )
-            timestamp_offsets = consumer.offsets_for_times(
-                {p: hour_offset for p in all_partitions}
+            timestamp_offsets = self._consumer.offsets_for_times(
+                {p: hour_offset for p in self._all_partitions}
             )
 
             for partition, offset_ts in timestamp_offsets.items():
                 if offset_ts is not None:
-                    consumer.seek(partition, offset_ts.offset)
-                    start_offset = offset_ts.offset
+                    self._consumer.seek(partition, offset_ts.offset)
+                    self._start_offset = offset_ts.offset
 
-        end_offsets = consumer.end_offsets(all_partitions)
-        current_offset = list(end_offsets.values())[0]
+        end_offsets = self._consumer.end_offsets(self._all_partitions)
+        self._current_offset = list(end_offsets.values())[0]
+
+        super()._start_processing()
+
+    def process(self):
+        if self._closed:
+            return
 
         sent_completed_status = False
-        while not self._closed:
-            for message in consumer:
-                if self._closed:
-                    break
 
+        records = self._consumer.poll(timeout_ms=250)
+        for partition in self._all_partitions:
+            batched_messages = records.get(partition, tuple())
+            for message in batched_messages:
                 self._logger.debug("Received new message: %s", message)
 
-                done_preloading = message.offset + 1 >= current_offset
+                done_preloading = message.offset + 1 >= self._current_offset
                 self.notify_go_to_last_automatically(done_preloading)
 
                 document_type, document = message.value
@@ -80,8 +86,8 @@ class KafkaDataSource(BlueskyDataSource):
                     else:
                         completion_percent = (
                             100
-                            * (message.offset - start_offset + 1)
-                            / (current_offset - start_offset)
+                            * (message.offset - self._start_offset + 1)
+                            / (self._current_offset - self._start_offset)
                         )
                     self.notify_loading_status(
                         "Loading runs from Kafka...", completion_percent
@@ -91,3 +97,5 @@ class KafkaDataSource(BlueskyDataSource):
 
     def close_thread(self):
         self._closed = True
+
+        super().close_thread()

--- a/src/sophys_live_view/utils/kafka_data_source.py
+++ b/src/sophys_live_view/utils/kafka_data_source.py
@@ -62,7 +62,7 @@ class KafkaDataSource(BlueskyDataSource):
                 if self._closed:
                     break
 
-                self._logger.debug("Received new message: %s", str(message))
+                self._logger.debug("Received new message: %s", message)
 
                 done_preloading = message.offset + 1 >= current_offset
                 self.notify_go_to_last_automatically(done_preloading)

--- a/src/sophys_live_view/utils/kafka_data_source.py
+++ b/src/sophys_live_view/utils/kafka_data_source.py
@@ -65,7 +65,7 @@ class KafkaDataSource(BlueskyDataSource):
                 self._logger.debug("Received new message: %s", str(message))
 
                 done_preloading = message.offset + 1 >= current_offset
-                self.go_to_last_automatically.emit(done_preloading)
+                self.notify_go_to_last_automatically(done_preloading)
 
                 document_type, document = message.value
 
@@ -83,7 +83,7 @@ class KafkaDataSource(BlueskyDataSource):
                             * (message.offset - start_offset + 1)
                             / (current_offset - start_offset)
                         )
-                    self.loading_status.emit(
+                    self.notify_loading_status(
                         "Loading runs from Kafka...", completion_percent
                     )
 

--- a/src/sophys_live_view/utils/kafka_data_source.py
+++ b/src/sophys_live_view/utils/kafka_data_source.py
@@ -30,7 +30,9 @@ class KafkaDataSource(BlueskyDataSource):
             self._topic_name,
             bootstrap_servers=self._bootstrap_servers,
             value_deserializer=msgpack.unpackb,
-            consumer_timeout_ms=250,
+            metrics_sample_window_ms=5000,
+            max_partition_fetch_bytes=1024 * 1024,
+            max_poll_records=5000,
         )
 
         self._all_partitions = [
@@ -64,7 +66,7 @@ class KafkaDataSource(BlueskyDataSource):
 
         sent_completed_status = False
 
-        records = self._consumer.poll(timeout_ms=250)
+        records = self._consumer.poll(timeout_ms=200)
         for partition in self._all_partitions:
             batched_messages = records.get(partition, tuple())
             for message in batched_messages:

--- a/src/sophys_live_view/utils/thread_utils.py
+++ b/src/sophys_live_view/utils/thread_utils.py
@@ -1,0 +1,58 @@
+from collections.abc import Callable
+
+from qtpy.QtCore import QCoreApplication, QObject, Qt, QThread, Slot
+
+
+def is_main_thread(thread: QThread) -> bool:
+    instance = QCoreApplication.instance()
+    assert instance is not None, "No QCoreApplication running."
+    return thread is instance.thread()
+
+
+class _ProxyThreadObject(QObject):
+    """Helper object for ensuring some function is called within its expected thread context."""
+
+    def __init__(
+        self,
+        thread: QThread,
+        started_proc_slot: Callable | None = None,
+        finished_proc_slot: Callable | None = None,
+    ):
+        super().__init__()
+
+        self.moveToThread(thread)
+
+        def do_nothing():
+            pass
+
+        self._started_proc_slot = (
+            started_proc_slot or do_nothing
+        )  # Help with type hints
+        if started_proc_slot is not None:
+            thread.started.connect(
+                self._on_started, type=Qt.ConnectionType.QueuedConnection
+            )
+
+        self._finished_proc_slot = (
+            finished_proc_slot or do_nothing
+        )  # Help with type hints
+        if finished_proc_slot is not None:
+            thread.finished.connect(
+                self._on_finished, type=Qt.ConnectionType.QueuedConnection
+            )
+
+    @Slot()
+    def _on_started(self):
+        assert not is_main_thread(QThread.currentThread()), (
+            "Running processing in main thread!"
+        )
+
+        self._started_proc_slot()
+
+    @Slot()
+    def _on_finished(self):
+        assert not is_main_thread(QThread.currentThread()), (
+            "Running processing in main thread!"
+        )
+
+        self._finished_proc_slot()

--- a/src/sophys_live_view/widgets/plot_display.py
+++ b/src/sophys_live_view/widgets/plot_display.py
@@ -95,7 +95,10 @@ class DataAggregator(QObject):
             if detector_name in metadata and "position" in metadata[detector_name]:
                 positions = metadata[detector_name]["position"]
                 for value, position in zip(detector_values, positions):
-                    self._data_cache[subuid][detector_name][position] = value
+                    try:
+                        self._data_cache[subuid][detector_name][position] = value
+                    except ValueError:  # Received an array for a data point
+                        pass
             else:
                 self._data_cache[subuid][detector_name] = np.append(
                     self._data_cache[subuid][detector_name], detector_values

--- a/src/sophys_live_view/widgets/plot_display.py
+++ b/src/sophys_live_view/widgets/plot_display.py
@@ -34,6 +34,9 @@ class DataAggregator(QObject):
         new_stream_signal.connect(self._on_new_stream)
         new_data_signal.connect(self._receive_new_data)
 
+        # NOTE: Used for testing.
+        self.total_processed_data_events = 0
+
     def get_data(self, uid: str, signal_name: str, *, force_1d: bool = False):
         data = self._data_cache[uid].get(signal_name, None)
         if force_1d and data is not None:
@@ -97,6 +100,8 @@ class DataAggregator(QObject):
             self.add_custom_signal(subuid, name, expression)
 
         self.new_data_received.emit(subuid)
+
+        self.total_processed_data_events += 1
 
 
 class PlotDisplay(IPlotDisplay):

--- a/src/sophys_live_view/widgets/plot_display.py
+++ b/src/sophys_live_view/widgets/plot_display.py
@@ -83,7 +83,14 @@ class DataAggregator(QObject):
             for detector in metadata.get("detectors", []):
                 self._data_cache[subuid][detector] = np.ones(metadata["shape"]) * np.nan
 
-    def _receive_new_data(self, uid: str, subuid: str, new_data: dict, metadata: dict):
+    def _receive_new_data(
+        self,
+        uid: str,
+        subuid: str,
+        number_of_events: int,
+        new_data: dict,
+        metadata: dict,
+    ):
         for detector_name, detector_values in new_data.items():
             if detector_name in metadata and "position" in metadata[detector_name]:
                 position = metadata[detector_name]["position"]
@@ -101,7 +108,7 @@ class DataAggregator(QObject):
 
         self.new_data_received.emit(subuid)
 
-        self.total_processed_data_events += 1
+        self.total_processed_data_events += number_of_events
 
 
 class PlotDisplay(IPlotDisplay):

--- a/src/sophys_live_view/widgets/plot_display.py
+++ b/src/sophys_live_view/widgets/plot_display.py
@@ -93,11 +93,9 @@ class DataAggregator(QObject):
     ):
         for detector_name, detector_values in new_data.items():
             if detector_name in metadata and "position" in metadata[detector_name]:
-                position = metadata[detector_name]["position"]
-                assert len(detector_values) == 1, (
-                    "Received multiple values for a single data position."
-                )
-                self._data_cache[subuid][detector_name][position] = detector_values[0]
+                positions = metadata[detector_name]["position"]
+                for value, position in zip(detector_values, positions):
+                    self._data_cache[subuid][detector_name][position] = value
             else:
                 self._data_cache[subuid][detector_name] = np.append(
                     self._data_cache[subuid][detector_name], detector_values

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,74 +1,119 @@
+from collections import deque
 import pathlib
 import uuid
 
-import numpy as np
 import pytest
 
-from sophys_live_view.utils.data_source import DataSource
+from sophys_live_view.utils.data_source import BatchReceivedDataSource, DataSource
 from sophys_live_view.utils.data_source_manager import DataSourceManager
 
 
-class DummyDataSource(DataSource):
-    def run(self):
-        uid = str(uuid.uuid4())
-        self.new_data_stream.emit(
-            uid,
-            "abc",
-            {"timestamp", "det"},
-            {},
-            set(("det",)),
-            ["timestamp"],
-            {"uid": uid, "stream_name": "abc"},
-        )
-        self.new_data_received.emit(
-            uid,
-            {"timestamp": np.array([1, 2, 3]), "det": np.array([1, 2, 3])},
-            {},
-        )
-        self.new_data_received.emit(
-            uid,
-            {"timestamp": np.array([4, 5, 6]), "det": np.array([5, 6, 7])},
-            {},
+class DummyDataSourceData:
+    def __iter__(self):
+        for type_index in self._order:
+            if type_index == 0:
+                uid = str(uuid.uuid4())
+
+            signal_name, arguments_list = self._data[type_index]
+            yield signal_name, (uid, *arguments_list.popleft())
+
+    def __init__(self):
+        self.new_data_stream = deque(
+            (
+                (
+                    "abc",
+                    {"timestamp", "det"},
+                    {},
+                    set(("det",)),
+                    ["timestamp"],
+                    {"stream_name": "abc"},
+                ),
+                (
+                    "ghi",
+                    {"timestamp", "det", "det2"},
+                    {},
+                    set(("det2",)),
+                    ["timestamp"],
+                    {
+                        "stream_name": "ghi",
+                        "configuration": {"one": "ghi", "two": {"two_three": "ghi"}},
+                    },
+                ),
+            )
         )
 
-        uid = str(uuid.uuid4())
-        self.new_data_stream.emit(
-            uid,
-            "ghi",
-            {"timestamp", "det", "det2"},
-            {},
-            set(("det2",)),
-            ["timestamp"],
-            {
-                "uid": uid,
-                "stream_name": "ghi",
-                "configuration": {"one": "ghi", "two": {"two_three": "ghi"}},
-            },
+        self.new_data_received = deque(
+            (
+                (
+                    3,
+                    {"timestamp": [1, 2, 3], "det": [1, 2, 3]},
+                    {},
+                ),
+                (
+                    3,
+                    {"timestamp": [4, 5, 6], "det": [5, 6, 7]},
+                    {},
+                ),
+                (
+                    3,
+                    {
+                        "timestamp": [1, 2, 3],
+                        "det": [2, 1, 3],
+                        "det2": [9, 8, 7],
+                    },
+                    {},
+                ),
+                (
+                    3,
+                    {
+                        "timestamp": [4, 5, 6],
+                        "det": [5, 9, 6],
+                        "det2": [1, 2, 3],
+                    },
+                    {},
+                ),
+            )
         )
-        self.new_data_received.emit(
-            uid,
-            {
-                "timestamp": np.array([1, 2, 3]),
-                "det": np.array([2, 1, 3]),
-                "det2": np.array([9, 8, 7]),
-            },
-            {},
+
+        self.data_stream_closed = deque(((), ()))
+
+        self._order = (0, 1, 1, 2, 0, 1, 1, 2)
+        self._data = (
+            ("new_data_stream", self.new_data_stream),
+            ("new_data_received", self.new_data_received),
+            ("data_stream_closed", self.data_stream_closed),
         )
-        self.new_data_received.emit(
-            uid,
-            {
-                "timestamp": np.array([4, 5, 6]),
-                "det": np.array([5, 9, 6]),
-                "det2": np.array([1, 2, 3]),
-            },
-            {},
-        )
+
+
+class DummyDataSource(DataSource):
+    def process(self):
+        _data = DummyDataSourceData()
+
+        for signal_name, arguments in _data:
+            getattr(self, signal_name).emit(*arguments)
+
+
+class BatchedDummyDataSource(BatchReceivedDataSource):
+    def process(self):
+        _data = DummyDataSourceData()
+
+        for signal_name, arguments in _data:
+            getattr(self, "notify_" + signal_name)(*arguments)
+
+
+@pytest.fixture
+def dummy_data_source():
+    return DummyDataSource()
+
+
+@pytest.fixture
+def batched_dummy_data_source():
+    return BatchedDummyDataSource()
 
 
 @pytest.fixture
 def data_source_manager():
     manager = DataSourceManager()
-    manager.add_data_source(DummyDataSource())
     yield manager
     manager.stop()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -67,7 +67,7 @@ class DummyDataSource(DataSource):
 
 @pytest.fixture
 def data_source_manager():
-    manager = DataSourceManager(polling_time=0.05)
+    manager = DataSourceManager()
     manager.add_data_source(DummyDataSource())
     yield manager
     manager.stop()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -99,6 +99,7 @@ class BatchedDummyDataSource(BatchReceivedDataSource):
 
         for signal_name, arguments in _data:
             getattr(self, "notify_" + signal_name)(*arguments)
+        self.dispatch_data.emit()
 
 
 @pytest.fixture

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -21,6 +21,8 @@ class BigStreamsDataSource(BatchReceivedDataSource):
         self._number_of_streams = number_of_streams
 
     def process(self):
+        empty_dict = {}
+
         def _send_stream():
             uid = str(uuid4())
 
@@ -37,7 +39,7 @@ class BigStreamsDataSource(BatchReceivedDataSource):
 
             for i in range(self._events_per_stream):
                 data = {f"signal_{n}": [i] for n in range(self._signals_per_event)}
-                self.notify_new_data_received(uid, 1, data, {})
+                self.notify_new_data_received(uid, 1, data, empty_dict)
 
             self.notify_data_stream_closed(uid)
 

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,66 +1,51 @@
 import time
 from uuid import uuid4
 
-import numpy as np
 import pytest
 from qtpy.QtCore import QObject, Signal
 
-from sophys_live_view.utils.bluesky_data_source import DataSource
-from sophys_live_view.utils.data_source_manager import DataSourceManager
+from sophys_live_view.utils.bluesky_data_source import BatchReceivedDataSource
 from sophys_live_view.widgets import PlotDisplay
 
 
-class BigStreamsDataSource(DataSource):
+class BigStreamsDataSource(BatchReceivedDataSource):
     def __init__(
         self, signals_per_event: int, events_per_stream: int, number_of_streams: int
     ):
         super().__init__()
 
+        self._dispatch_time = 25
+
         self._signals_per_event = signals_per_event
         self._events_per_stream = events_per_stream
         self._number_of_streams = number_of_streams
 
-    def run(self):
+    def process(self):
         def _send_stream():
             uid = str(uuid4())
 
             signals = {f"signal_{n}" for n in range(self._signals_per_event)}
-            self.new_data_stream.emit(
+            self.notify_new_data_stream(
                 uid,
                 "Stream",
                 signals,
                 {},
-                {},
+                set(),
                 [],
                 {},
             )
 
             for i in range(self._events_per_stream):
-                data = {
-                    f"signal_{n}": np.array([i]) for n in range(self._signals_per_event)
-                }
-                self.new_data_received.emit(uid, data, {})
+                data = {f"signal_{n}": [i] for n in range(self._signals_per_event)}
+                self.notify_new_data_received(uid, 1, data, {})
 
-            self.data_stream_closed.emit(uid)
+            self.notify_data_stream_closed(uid)
 
         for _ in range(self._number_of_streams):
             _send_stream()
 
     def total_number_of_events(self):
         return self._events_per_stream * self._number_of_streams
-
-    def close_thread(self):
-        assert not self.isRunning()
-
-
-@pytest.fixture
-def empty_manager():
-    manager = DataSourceManager(polling_time=0.05)
-
-    yield manager
-
-    if manager.isRunning():
-        manager.stop()
 
 
 class MockSignals(QObject):
@@ -76,9 +61,9 @@ def signals_mocker():
 
 
 @pytest.fixture
-def display(empty_manager, signals_mocker, qtbot):
+def display(data_source_manager, signals_mocker, qtbot):
     display = PlotDisplay(
-        empty_manager,
+        data_source_manager,
         signals_mocker.selected_streams_changed,
         signals_mocker.selected_signals_changed_1d,
         signals_mocker.selected_signals_changed_2d,
@@ -101,7 +86,7 @@ def test_big_streams(
     events_per_stream,
     number_of_streams,
     benchmark,
-    empty_manager,
+    data_source_manager,
     display,
     qtbot,
 ):
@@ -114,8 +99,8 @@ def test_big_streams(
         data_source = BigStreamsDataSource(
             signals_per_event, events_per_stream, number_of_streams
         )
-        empty_manager.add_data_source(data_source)
-        empty_manager.start()
+        data_source_manager.add_data_source(data_source)
+        data_source_manager.start()
 
         _start_time = time.time()
         while (
@@ -124,7 +109,7 @@ def test_big_streams(
         ):
             if time.time() - _start_time >= 10.0:
                 pytest.fail(
-                    f"Timed out: Processed {data_aggr.total_processed_data_events} events."
+                    f"Timed out: Processed {data_aggr.total_processed_data_events} events out of {data_source.total_number_of_events()}."
                 )
 
             qtbot.wait(25)

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -14,8 +14,6 @@ class BigStreamsDataSource(BatchReceivedDataSource):
     ):
         super().__init__()
 
-        self._dispatch_time = 25
-
         self._signals_per_event = signals_per_event
         self._events_per_stream = events_per_stream
         self._number_of_streams = number_of_streams
@@ -45,6 +43,8 @@ class BigStreamsDataSource(BatchReceivedDataSource):
 
         for _ in range(self._number_of_streams):
             _send_stream()
+
+            self.dispatch_data.emit()
 
     def total_number_of_events(self):
         return self._events_per_stream * self._number_of_streams

--- a/tests/test_benchmark.py
+++ b/tests/test_benchmark.py
@@ -1,0 +1,132 @@
+import time
+from uuid import uuid4
+
+import numpy as np
+import pytest
+from qtpy.QtCore import QObject, Signal
+
+from sophys_live_view.utils.bluesky_data_source import DataSource
+from sophys_live_view.utils.data_source_manager import DataSourceManager
+from sophys_live_view.widgets import PlotDisplay
+
+
+class BigStreamsDataSource(DataSource):
+    def __init__(
+        self, signals_per_event: int, events_per_stream: int, number_of_streams: int
+    ):
+        super().__init__()
+
+        self._signals_per_event = signals_per_event
+        self._events_per_stream = events_per_stream
+        self._number_of_streams = number_of_streams
+
+    def run(self):
+        def _send_stream():
+            uid = str(uuid4())
+
+            signals = {f"signal_{n}" for n in range(self._signals_per_event)}
+            self.new_data_stream.emit(
+                uid,
+                "Stream",
+                signals,
+                {},
+                {},
+                [],
+                {},
+            )
+
+            for i in range(self._events_per_stream):
+                data = {
+                    f"signal_{n}": np.array([i]) for n in range(self._signals_per_event)
+                }
+                self.new_data_received.emit(uid, data, {})
+
+            self.data_stream_closed.emit(uid)
+
+        for _ in range(self._number_of_streams):
+            _send_stream()
+
+    def total_number_of_events(self):
+        return self._events_per_stream * self._number_of_streams
+
+    def close_thread(self):
+        assert not self.isRunning()
+
+
+@pytest.fixture
+def empty_manager():
+    manager = DataSourceManager(polling_time=0.05)
+
+    yield manager
+
+    if manager.isRunning():
+        manager.stop()
+
+
+class MockSignals(QObject):
+    selected_streams_changed = Signal(list)
+    selected_signals_changed_1d = Signal(str, set)
+    selected_signals_changed_2d = Signal(str, str, set)
+    custom_signal_added = Signal(str, str, str)
+
+
+@pytest.fixture
+def signals_mocker():
+    return MockSignals()
+
+
+@pytest.fixture
+def display(empty_manager, signals_mocker, qtbot):
+    display = PlotDisplay(
+        empty_manager,
+        signals_mocker.selected_streams_changed,
+        signals_mocker.selected_signals_changed_1d,
+        signals_mocker.selected_signals_changed_2d,
+        signals_mocker.custom_signal_added,
+    )
+    qtbot.addWidget(display)
+    return display
+
+
+@pytest.mark.benchmark(
+    max_time=10.0,
+    warmup=False,
+)
+@pytest.mark.parametrize(
+    ("signals_per_event", "events_per_stream", "number_of_streams"),
+    ((2, 1000, 10), (10, 1000, 2), (2, 10000, 1), (20, 10000, 1), (200, 1000, 1)),
+)
+def test_big_streams(
+    signals_per_event,
+    events_per_stream,
+    number_of_streams,
+    benchmark,
+    empty_manager,
+    display,
+    qtbot,
+):
+    data_aggr = display._data_aggregator
+
+    @benchmark
+    def __inner():
+        data_aggr.total_processed_data_events = 0
+
+        data_source = BigStreamsDataSource(
+            signals_per_event, events_per_stream, number_of_streams
+        )
+        empty_manager.add_data_source(data_source)
+        empty_manager.start()
+
+        _start_time = time.time()
+        while (
+            data_aggr.total_processed_data_events
+            != data_source.total_number_of_events()
+        ):
+            if time.time() - _start_time >= 10.0:
+                pytest.fail(
+                    f"Timed out: Processed {data_aggr.total_processed_data_events} events."
+                )
+
+            qtbot.wait(25)
+
+    assert __inner is None

--- a/tests/utils/test_data_source.py
+++ b/tests/utils/test_data_source.py
@@ -61,7 +61,6 @@ def test_bluesky_load_from_json_batching(
     data_source_manager, file_name, event_count, test_data_path, qtbot
 ):
     data_source = JSONDataSource(str(test_data_path / file_name))
-    data_source._dispatch_time = 50  # Arbitrary time
     data_source_manager.add_data_source(data_source)
 
     with qtbot.waitSignal(

--- a/tests/utils/test_data_source.py
+++ b/tests/utils/test_data_source.py
@@ -6,7 +6,7 @@ from sophys_live_view.utils.json_data_source import JSONDataSource
 
 @pytest.fixture
 def empty_manager():
-    manager = DataSourceManager(polling_time=0.05)
+    manager = DataSourceManager()
 
     yield manager
 

--- a/tests/utils/test_data_source.py
+++ b/tests/utils/test_data_source.py
@@ -1,26 +1,25 @@
 import pytest
 
-from sophys_live_view.utils.data_source_manager import DataSourceManager
 from sophys_live_view.utils.json_data_source import JSONDataSource
 
 
-@pytest.fixture
-def empty_manager():
-    manager = DataSourceManager()
-
-    yield manager
-
-    if manager.isRunning():
-        manager.stop()
-
-
-def test_data_source_declare_stream(data_source_manager, qtbot):
+def test_data_source_declare_stream(data_source_manager, dummy_data_source, qtbot):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
 
-def test_data_source_stream_data(data_source_manager, qtbot):
+def test_data_source_stream_data(data_source_manager, dummy_data_source, qtbot):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_received] * 4, timeout=1000):
+        data_source_manager.start()
+
+
+def test_data_source_stream_data_batched(
+    data_source_manager, batched_dummy_data_source, qtbot
+):
+    data_source_manager.add_data_source(batched_dummy_data_source)
+    with qtbot.waitSignals([data_source_manager.new_data_received] * 2, timeout=1000):
         data_source_manager.start()
 
 
@@ -35,22 +34,57 @@ def test_data_source_stream_data(data_source_manager, qtbot):
     ],
 )
 def test_bluesky_load_from_json(
-    empty_manager, file_name, event_count, test_data_path, qtbot
+    data_source_manager, file_name, event_count, test_data_path, qtbot
 ):
     data_source = JSONDataSource(str(test_data_path / file_name))
-    empty_manager.add_data_source(data_source)
+    data_source._should_passthrough = True
+    data_source_manager.add_data_source(data_source)
 
     with qtbot.waitSignals(
-        [empty_manager.new_data_received] * event_count, timeout=2000
+        [data_source_manager.new_data_received] * event_count, timeout=2000
     ):
-        with qtbot.waitSignal(empty_manager.new_data_stream, timeout=1000):
-            empty_manager.start()
+        with qtbot.waitSignal(data_source_manager.new_data_stream, timeout=1000):
+            data_source_manager.start()
 
 
-def test_data_source_after_start(empty_manager, test_data_path, qtbot):
-    empty_manager.start()
+@pytest.mark.parametrize(
+    "file_name,event_count",
+    [
+        ("count_with_rand.json", 50),
+        ("scan_with_rand.json", 11),
+        ("scan_with_det.json", 21),
+        ("grid_with_rand.json", 121),
+        ("grid_with_det.json", 231),
+    ],
+)
+def test_bluesky_load_from_json_batching(
+    data_source_manager, file_name, event_count, test_data_path, qtbot
+):
+    data_source = JSONDataSource(str(test_data_path / file_name))
+    data_source._dispatch_time = 50  # Arbitrary time
+    data_source_manager.add_data_source(data_source)
+
+    with qtbot.waitSignal(
+        data_source_manager.new_data_received, timeout=1000
+    ) as blocker:
+        with qtbot.waitSignal(data_source_manager.new_data_stream, timeout=1000):
+            data_source_manager.start()
+
+    _, _, number_of_events, received_data, _ = blocker.args
+
+    assert all(
+        [len(data_points) == number_of_events for data_points in received_data.values()]
+    )
+    assert number_of_events == event_count, (
+        f"Got: {number_of_events} | Expected: {event_count}"
+    )
+
+
+def test_data_source_after_start(data_source_manager, test_data_path, qtbot):
+    data_source_manager.start()
 
     data_source = JSONDataSource(str(test_data_path / "count_with_rand.json"))
-    with qtbot.waitSignals([empty_manager.new_data_received] * 50, timeout=2000):
-        with qtbot.waitSignal(empty_manager.new_data_stream, timeout=1000):
-            empty_manager.add_data_source(data_source)
+    data_source._should_passthrough = True
+    with qtbot.waitSignals([data_source_manager.new_data_received] * 50, timeout=2000):
+        with qtbot.waitSignal(data_source_manager.new_data_stream, timeout=1000):
+            data_source_manager.add_data_source(data_source)

--- a/tests/widgets/test_metadata_viewer.py
+++ b/tests/widgets/test_metadata_viewer.py
@@ -23,7 +23,7 @@ def viewer(data_source_manager, signals_mocker, qtbot):
     return selector
 
 
-def test_acquire_metadata(viewer, data_source_manager, qtbot):
+def test_acquire_metadata(viewer, data_source_manager, dummy_data_source, qtbot):
     name_to_uid = {}
 
     data_source_manager.new_data_stream.connect(
@@ -44,11 +44,14 @@ def test_acquire_metadata(viewer, data_source_manager, qtbot):
             == "ghi"
         )
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.start()
     qtbot.waitUntil(metadata_complete, timeout=1000)
 
 
-def test_select_stream(viewer, data_source_manager, signals_mocker, qtbot):
+def test_select_stream(
+    viewer, data_source_manager, dummy_data_source, signals_mocker, qtbot
+):
     uids_and_names = []
 
     data_source_manager.new_data_stream.connect(
@@ -62,6 +65,7 @@ def test_select_stream(viewer, data_source_manager, signals_mocker, qtbot):
         assert viewer._tab.tabText(0) == "abc"
         assert viewer._tab.tabText(1) == "ghi"
 
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
@@ -69,17 +73,15 @@ def test_select_stream(viewer, data_source_manager, signals_mocker, qtbot):
     qtbot.waitUntil(tabs_populated, timeout=1000)
 
     abc_page: QTableWidget = viewer._tab.widget(0)
-    assert abc_page.rowCount() == 2
+    assert abc_page.rowCount() == 1
     assert abc_page.item(0, 0).text() == "stream_name"
     assert abc_page.item(0, 1).text() == "abc"
-    assert abc_page.item(1, 0).text() == "uid"
 
     ghi_page: QTableWidget = viewer._tab.widget(1)
-    assert ghi_page.rowCount() == 4
+    assert ghi_page.rowCount() == 3
     assert ghi_page.item(0, 0).text() == "stream_name"
     assert ghi_page.item(0, 1).text() == "ghi"
-    assert ghi_page.item(1, 0).text() == "uid"
-    assert ghi_page.item(2, 0).text() == "configuration - one"
+    assert ghi_page.item(1, 0).text() == "configuration - one"
+    assert ghi_page.item(1, 1).text() == "ghi"
+    assert ghi_page.item(2, 0).text() == "configuration - two - three"
     assert ghi_page.item(2, 1).text() == "ghi"
-    assert ghi_page.item(3, 0).text() == "configuration - two - three"
-    assert ghi_page.item(3, 1).text() == "ghi"

--- a/tests/widgets/test_plot_display.py
+++ b/tests/widgets/test_plot_display.py
@@ -43,13 +43,29 @@ def test_plot_change_tab(display, qtbot):
     assert "1D" in blocker.args[0], blocker.args
 
 
-def test_plot_get_data(data_source_manager, display, qtbot):
+def test_plot_get_data(data_source_manager, dummy_data_source, display, qtbot):
+    data_source_manager.add_data_source(dummy_data_source)
+
     data_aggr = display._data_aggregator
     with qtbot.waitSignals([data_aggr.new_data_received] * 4, timeout=1000):
         data_source_manager.start()
 
 
-def test_plot_draw_1d_curve(data_source_manager, display, signals_mocker, qtbot):
+def test_plot_get_batched_data(
+    data_source_manager, batched_dummy_data_source, display, qtbot
+):
+    data_source_manager.add_data_source(batched_dummy_data_source)
+
+    data_aggr = display._data_aggregator
+    with qtbot.waitSignals([data_aggr.new_data_received] * 2, timeout=1000):
+        data_source_manager.start()
+
+
+def test_plot_draw_1d_curve(
+    data_source_manager, dummy_data_source, display, signals_mocker, qtbot
+):
+    data_source_manager.add_data_source(dummy_data_source)
+
     uids_and_names = []
 
     data_source_manager.new_data_stream.connect(
@@ -74,7 +90,40 @@ def test_plot_draw_1d_curve(data_source_manager, display, signals_mocker, qtbot)
     qtbot.waitUntil(finished_building_plot, timeout=1000)
 
 
-def test_plot_add_custom_signal(data_source_manager, display, signals_mocker, qtbot):
+def test_plot_draw_1d_curve_batched(
+    data_source_manager, batched_dummy_data_source, display, signals_mocker, qtbot
+):
+    data_source_manager.add_data_source(batched_dummy_data_source)
+
+    uids_and_names = []
+
+    data_source_manager.new_data_stream.connect(
+        lambda uid, subuid, display_name, *_: uids_and_names.append(
+            (subuid, display_name)
+        )
+    )
+
+    data_aggr = display._data_aggregator
+    with qtbot.waitSignals([data_aggr.new_data_received] * 2, timeout=1000):
+        data_source_manager.start()
+
+    signals_mocker.selected_streams_changed.emit(uids_and_names)
+    signals_mocker.selected_signals_changed_1d.emit("timestamp", {"det", "det2"})
+
+    def finished_building_plot():
+        assert display._stacked_widget.currentWidget() is display._plots
+        assert len(display._plots.widget(0).getItems()) == 3
+
+    display.show()
+    qtbot.waitExposed(display, timeout=1000)
+    qtbot.waitUntil(finished_building_plot, timeout=1000)
+
+
+def test_plot_add_custom_signal(
+    data_source_manager, dummy_data_source, display, signals_mocker, qtbot
+):
+    data_source_manager.add_data_source(dummy_data_source)
+
     uids_and_names = []
 
     data_source_manager.new_data_stream.connect(
@@ -93,7 +142,10 @@ def test_plot_add_custom_signal(data_source_manager, display, signals_mocker, qt
     det2_data = data_aggr.get_data(uids_and_names[1][0], "det2")
     custom_data = data_aggr.get_data(uids_and_names[1][0], "test")
 
-    assert all(custom_data[i] == det2_data[i] - det_data[i] for i in range(custom_data.shape[0]))
+    assert all(
+        custom_data[i] == det2_data[i] - det_data[i]
+        for i in range(custom_data.shape[0])
+    )
 
 
 # FIXME: Figure out why this test hangs when running with the other plot display tests,

--- a/tests/widgets/test_run_selector.py
+++ b/tests/widgets/test_run_selector.py
@@ -11,9 +11,12 @@ def selector(data_source_manager, qtbot):
     return selector
 
 
-def test_run_selector_basic_load(selector, data_source_manager, qtbot):
+def test_run_selector_basic_load(
+    selector, data_source_manager, dummy_data_source, qtbot
+):
     assert selector._run_list_model.rowCount() == 0
 
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
@@ -24,7 +27,10 @@ def test_run_selector_basic_load(selector, data_source_manager, qtbot):
     assert selector._run_list_model.data(index) == "ghi"
 
 
-def test_run_selector_select_one(selector, data_source_manager, qtbot):
+def test_run_selector_select_one(
+    selector, data_source_manager, dummy_data_source, qtbot
+):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
@@ -35,7 +41,10 @@ def test_run_selector_select_one(selector, data_source_manager, qtbot):
     assert blocker.args[0][0][1] == "ghi", blocker.args[0]
 
 
-def test_run_selector_select_multiple(selector, data_source_manager, qtbot):
+def test_run_selector_select_multiple(
+    selector, data_source_manager, dummy_data_source, qtbot
+):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 
@@ -55,7 +64,8 @@ def test_run_selector_select_multiple(selector, data_source_manager, qtbot):
     assert args[0][1][1] == "ghi", args[0]
 
 
-def test_run_selector_bookmark(selector, data_source_manager, qtbot):
+def test_run_selector_bookmark(selector, data_source_manager, dummy_data_source, qtbot):
+    data_source_manager.add_data_source(dummy_data_source)
     with qtbot.waitSignals([data_source_manager.new_data_stream] * 2, timeout=1000):
         data_source_manager.start()
 

--- a/tests/widgets/test_signal_selector.py
+++ b/tests/widgets/test_signal_selector.py
@@ -22,9 +22,12 @@ def selector(data_source_manager, signals_mocker, qtbot):
     return selector
 
 
-def test_default_signals_1d(data_source_manager, selector, signals_mocker, qtbot):
+def test_default_signals_1d(
+    data_source_manager, dummy_data_source, selector, signals_mocker, qtbot
+):
     uids_and_names = []
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.new_data_stream.connect(
         lambda uid, subuid, display_name, *_: uids_and_names.append(
             (subuid, display_name)
@@ -42,9 +45,12 @@ def test_default_signals_1d(data_source_manager, selector, signals_mocker, qtbot
     assert "det" in blocker.args[1], blocker.args
 
 
-def test_change_signals_1d(data_source_manager, selector, signals_mocker, qtbot):
+def test_change_signals_1d(
+    data_source_manager, dummy_data_source, selector, signals_mocker, qtbot
+):
     uids_and_names = []
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.new_data_stream.connect(
         lambda uid, subuid, display_name, *_: uids_and_names.append(
             (subuid, display_name)
@@ -71,10 +77,11 @@ def test_change_signals_1d(data_source_manager, selector, signals_mocker, qtbot)
 
 
 def test_maintain_signals_between_runs_1d(
-    data_source_manager, selector, signals_mocker, qtbot
+    data_source_manager, dummy_data_source, selector, signals_mocker, qtbot
 ):
     uids_and_names = []
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.new_data_stream.connect(
         lambda uid, subuid, display_name, *_: uids_and_names.append(
             (subuid, display_name)
@@ -109,9 +116,10 @@ def test_maintain_signals_between_runs_1d(
     assert "timestamp" in blocker.args[1], blocker.args
 
 
-def test_add_custom_signal(data_source_manager, selector, qtbot):
+def test_add_custom_signal(data_source_manager, dummy_data_source, selector, qtbot):
     uids_and_names = []
 
+    data_source_manager.add_data_source(dummy_data_source)
     data_source_manager.new_data_stream.connect(
         lambda uid, subuid, display_name, *_: uids_and_names.append(
             (subuid, display_name)


### PR DESCRIPTION
Here is a comparison of benchmarks from before and after these changes:

<details>
<summary>Old result (before last push)</summary>
<code>
Name (time in ms)                             Min                 Max                Mean            StdDev          Rounds
----------------------------------------------------------------------------------------------------------------------------
test_big_streams[10-1000-2]  (MAIN)       227.3389 (4.74)     405.0768 (5.90)     281.6644 (5.46)    39.1389 (11.21)      36
test_big_streams[10-1000-2]  (OPTIMIZ)     48.0071 (1.0)       68.6364 (1.0)       51.6306 (1.0)      3.4930 (1.0)       187
----------------------------------------------------------------------------------------------------------------------------
test_big_streams[2-1000-10]  (MAIN)       634.9748 (13.59)    850.7526 (9.59)     684.2972 (10.61)   56.1005 (5.90)       14
test_big_streams[2-1000-10]  (OPTIMIZ)     46.7326 (1.0)       88.6849 (1.0)       64.4711 (1.0)      9.5166 (1.0)       172
----------------------------------------------------------------------------------------------------------------------------
test_big_streams[2-10000-1]  (MAIN)       731.0965 (12.34)  1,278.4803 (17.29)    948.2689 (14.43)  148.3288 (48.76)      15
test_big_streams[2-10000-1]  (OPTIMIZ)     59.2645 (1.0)       73.9370 (1.0)       65.7248 (1.0)      3.0420 (1.0)       133
----------------------------------------------------------------------------------------------------------------------------
test_big_streams[20-10000-1] (MAIN)     2,398.9859 (9.31)   2,587.7155 (9.21)   2,490.8157 (9.43)    78.4861 (12.90)       5
test_big_streams[20-10000-1] (OPTIMIZ)    257.7612 (1.0)      280.9660 (1.0)      264.2180 (1.0)      6.0839 (1.0)        34
----------------------------------------------------------------------------------------------------------------------------
test_big_streams[200-1000-1] (MAIN)     1,413.2308 (6.38)   1,514.5151 (6.07)   1,471.3543 (6.34)    36.0728 (6.92)        7
test_big_streams[200-1000-1] (OPTIMIZ)    221.4164 (1.0)      249.5026 (1.0)      232.0198 (1.0)      5.2147 (1.0)        42
----------------------------------------------------------------------------------------------------------------------------
</code>
</details>

<details>
<summary>Updated results</summary>
<code>
Name (time in ms)                  Min      Max     Mean  StdDev  Rounds
------------------------------------------------------------------------
test_big_streams[10-1000-2]    23.7346  28.1059  25.0591  0.5639     385
------------------------------------------------------------------------
test_big_streams[2-1000-10]    23.9764  62.2227  25.2879  2.6992     373
------------------------------------------------------------------------
test_big_streams[2-10000-1]    23.6411  26.9984  25.0099  0.5044     378
------------------------------------------------------------------------
test_big_streams[20-10000-1]   69.6053  98.4135  84.6255  8.2170     107
------------------------------------------------------------------------
test_big_streams[200-1000-1]   56.2801  93.5961  72.0741  7.1903     123
------------------------------------------------------------------------
</code>
</details>

One of the main benefits of this patchset is that it fixes a longstanding issue with our handling of `QThread`s, where we would actually not run a separate event loop for each DataSource. This means that our signal emissions would all happen in the main thread event loop, which would make the GUI feel sluggish while retrieving data.