### PR TITLE
Remove keyword argument from eval call

### DIFF
--- a/src/sophys_live_view/widgets/signal_selector.py
+++ b/src/sophys_live_view/widgets/signal_selector.py
@@ -687,7 +687,7 @@ Aside from the direct usage of <code>np</code>, for convenience, the following o
             environment[detector] = np.array([1, 2, 3])
 
         try:
-            eval(expression, locals=environment)
+            eval(expression, None, environment)
 
             return True, None
         except Exception as e:


### PR DESCRIPTION
This re-adds support for custom expressions in Python < 3.13. Missing from 859a27bc3077d2a20fafd6e902154fc3cfc48973.