### PR TITLE
Fix compatibility with `kafka-python` `>=` `3.0.0`

### DIFF
--- a/src/sophys_live_view/utils/kafka_data_source.py
+++ b/src/sophys_live_view/utils/kafka_data_source.py
@@ -31,6 +31,7 @@ class KafkaDataSource(BlueskyDataSource):
             bootstrap_servers=self._bootstrap_servers,
             value_deserializer=msgpack.unpackb,
             consumer_timeout_ms=250,
+            receive_message_max_bytes=100000000,
         )
 
         all_partitions = [


### PR DESCRIPTION
This change only prevents the fetching to fail due to frames being
too big, otherwise everything works the same from the old version.